### PR TITLE
auto-rewrite short repo URLs to archive zips

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ Expand a repository archive and include only Go files:
 lx -Z -i "*.go" https://github.com/owner/repo/archive/refs/heads/main.zip
 ```
 
+Short repo URLs are auto-rewritten to the host's archive zip and expanded automatically — no `-Z` needed. Works for GitHub, GitLab, Bitbucket, and Codeberg, with or without the scheme:
+```bash
+lx github.com/owner/repo
+lx https://gitlab.com/owner/repo/-/tree/dev
+```
+
 ### Document extraction
 Extract text from documents instead of treating them as binary:
 ```bash

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -202,8 +202,15 @@ func processStream(ctx context.Context, parsed *ParsedArgs) error {
 				rawPath := op.Value
 				isForced := op.Action == "file"
 
+				forceExpand := false
+				if rewritten, ok := lx.RewriteRepoURL(rawPath); ok {
+					slog.Debug("Rewrote repo URL to archive", "from", rawPath, "to", rewritten)
+					rawPath = rewritten
+					forceExpand = true
+				}
+
 				if lx.IsHTTPURL(rawPath) {
-					if section.RunCfg.ExpandArchives && lx.IsHTTPArchiveURL(rawPath) {
+					if (section.RunCfg.ExpandArchives || forceExpand) && lx.IsHTTPArchiveURL(rawPath) {
 						if !isForced && !lx.IsKept(rawPath, nil, section.Excludes) {
 							slog.Debug("Skipping URL archive due to exclude filter", "url", rawPath)
 							continue

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -7,12 +7,14 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/rasros/lx/pkg/lx"
+	"github.com/rasros/lx/pkg/lx/sources"
 )
 
 func TestRun_Basic(t *testing.T) {
@@ -158,6 +160,58 @@ func TestRun_HTTPURLArchiveInput_Expand(t *testing.T) {
 		t.Fatalf("Run() error: %v", err)
 	}
 	if !strings.Contains(out, url+"/repo-main/README.md") {
+		t.Fatalf("output missing expanded archive entry. Got:\n%s", out)
+	}
+	if !strings.Contains(out, "hello archive") {
+		t.Fatalf("output missing expanded archive content. Got:\n%s", out)
+	}
+}
+
+func TestRun_ShortRepoURL_AutoExpand(t *testing.T) {
+	var zipBuf bytes.Buffer
+	zw := zip.NewWriter(&zipBuf)
+	w, err := zw.Create("repo-main/README.md")
+	if err != nil {
+		t.Fatalf("Create zip entry: %v", err)
+	}
+	if _, err := w.Write([]byte("hello archive")); err != nil {
+		t.Fatalf("Write zip entry: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("Close zip writer: %v", err)
+	}
+
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/zip")
+		_, _ = w.Write(zipBuf.Bytes())
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	restore := sources.SetRepoHostForTest(serverURL.Host, func(owner, repo, ref string) string {
+		if ref == "" {
+			ref = "HEAD"
+		}
+		return server.URL + "/" + owner + "/" + repo + "/archive/" + ref + ".zip"
+	})
+	defer restore()
+
+	short := serverURL.Host + "/owner/repo"
+	out, err := captureStdout(func() error {
+		return Run(context.Background(), []string{short})
+	})
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if want := "/owner/repo/archive/HEAD.zip"; gotPath != want {
+		t.Fatalf("server got path %q, want %q", gotPath, want)
+	}
+	if !strings.Contains(out, "/repo-main/README.md") {
 		t.Fatalf("output missing expanded archive entry. Got:\n%s", out)
 	}
 	if !strings.Contains(out, "hello archive") {

--- a/pkg/lx/facade.go
+++ b/pkg/lx/facade.go
@@ -83,6 +83,8 @@ func IsHTTPURL(raw string) bool { return sources.IsHTTPURL(raw) }
 
 func IsHTTPArchiveURL(raw string) bool { return sources.IsHTTPArchiveURL(raw) }
 
+func RewriteRepoURL(raw string) (string, bool) { return sources.RewriteRepoURL(raw) }
+
 func NewURLInputFile(raw string) (InputFile, error) { return sources.NewURLInputFile(raw) }
 
 func DownloadURLToTempFile(ctx context.Context, raw string) (path string, cleanup func(), err error) {

--- a/pkg/lx/sources/repo_url.go
+++ b/pkg/lx/sources/repo_url.go
@@ -1,0 +1,204 @@
+package sources
+
+import (
+	"strings"
+	"sync"
+)
+
+// RewriteRepoURL inspects raw and, if it matches a known repo-host pattern
+// (GitHub, GitLab, Bitbucket, Codeberg), returns the archive-zip URL for that
+// repo and true. Otherwise returns "", false.
+//
+// Accepts input with or without an http(s) scheme. URLs that already point at
+// a host-specific archive segment (e.g. /archive/, /-/archive/, /get/) are
+// left alone.
+func RewriteRepoURL(raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", false
+	}
+
+	withScheme := raw
+	if !strings.Contains(raw, "://") {
+		withScheme = "https://" + raw
+	}
+
+	u, err := parseHTTPURL(withScheme)
+	if err != nil {
+		return "", false
+	}
+
+	host := strings.ToLower(u.Host)
+	repoHostsMu.RLock()
+	rewriter, ok := repoHosts[host]
+	repoHostsMu.RUnlock()
+	if !ok {
+		return "", false
+	}
+
+	path := strings.Trim(u.Path, "/")
+	if path == "" {
+		return "", false
+	}
+	parts := strings.Split(path, "/")
+
+	owner, repo, ref, ok := rewriter.parse(parts)
+	if !ok || owner == "" || repo == "" {
+		return "", false
+	}
+	return rewriter.archiveURL(owner, repo, ref), true
+}
+
+type repoRewriter struct {
+	// parse extracts (owner, repo, ref) from path segments. Returns ok=false
+	// when the path doesn't match the host's recognized shape (e.g. a
+	// /blob/, /releases/, or /archive/ path) — the caller leaves such URLs
+	// alone. The host is responsible for rejecting its own archive shape;
+	// the matcher should only accept "/owner/repo[/{tree,src,...}/{ref}]".
+	parse func(parts []string) (owner, repo, ref string, ok bool)
+	// archiveURL composes the archive-zip URL. ref="" means "default branch".
+	archiveURL func(owner, repo, ref string) string
+}
+
+func trimRepo(s string) string { return strings.TrimSuffix(s, ".git") }
+
+var (
+	repoHostsMu sync.RWMutex
+	repoHosts   = map[string]repoRewriter{
+		"github.com": {
+			parse: func(parts []string) (owner, repo, ref string, ok bool) {
+				if len(parts) < 2 {
+					return "", "", "", false
+				}
+				owner, repo = parts[0], trimRepo(parts[1])
+				rest := parts[2:]
+				if len(rest) == 0 {
+					return owner, repo, "", true
+				}
+				if rest[0] == "tree" && len(rest) >= 2 {
+					return owner, repo, strings.Join(rest[1:], "/"), true
+				}
+				return "", "", "", false
+			},
+			archiveURL: func(owner, repo, ref string) string {
+				if ref == "" {
+					return "https://github.com/" + owner + "/" + repo + "/archive/HEAD.zip"
+				}
+				return "https://github.com/" + owner + "/" + repo + "/archive/refs/heads/" + ref + ".zip"
+			},
+		},
+		"gitlab.com": {
+			parse: func(parts []string) (owner, repo, ref string, ok bool) {
+				// GitLab supports subgroups: group[/subgroup...]/repo[/-/tree/REF].
+				sep := -1
+				for i, p := range parts {
+					if p == "-" {
+						sep = i
+						break
+					}
+				}
+				var project, rest []string
+				if sep >= 0 {
+					project = parts[:sep]
+					rest = parts[sep+1:]
+				} else {
+					project = parts
+				}
+				if len(project) < 2 {
+					return "", "", "", false
+				}
+				owner = strings.Join(project[:len(project)-1], "/")
+				repo = trimRepo(project[len(project)-1])
+				if len(rest) == 0 {
+					return owner, repo, "", true
+				}
+				if len(rest) >= 2 && rest[0] == "tree" {
+					return owner, repo, strings.Join(rest[1:], "/"), true
+				}
+				return "", "", "", false
+			},
+			archiveURL: func(owner, repo, ref string) string {
+				r := ref
+				if r == "" {
+					r = "HEAD"
+				}
+				return "https://gitlab.com/" + owner + "/" + repo + "/-/archive/" + r + "/" + repo + "-" + r + ".zip"
+			},
+		},
+		"bitbucket.org": {
+			parse: func(parts []string) (owner, repo, ref string, ok bool) {
+				if len(parts) < 2 {
+					return "", "", "", false
+				}
+				owner, repo = parts[0], trimRepo(parts[1])
+				rest := parts[2:]
+				if len(rest) == 0 {
+					return owner, repo, "", true
+				}
+				if rest[0] == "src" && len(rest) >= 2 {
+					return owner, repo, strings.Join(rest[1:], "/"), true
+				}
+				return "", "", "", false
+			},
+			archiveURL: func(owner, repo, ref string) string {
+				r := ref
+				if r == "" {
+					r = "HEAD"
+				}
+				return "https://bitbucket.org/" + owner + "/" + repo + "/get/" + r + ".zip"
+			},
+		},
+		"codeberg.org": {
+			parse: func(parts []string) (owner, repo, ref string, ok bool) {
+				if len(parts) < 2 {
+					return "", "", "", false
+				}
+				owner, repo = parts[0], trimRepo(parts[1])
+				rest := parts[2:]
+				if len(rest) == 0 {
+					return owner, repo, "", true
+				}
+				if len(rest) >= 3 && rest[0] == "src" && rest[1] == "branch" {
+					return owner, repo, strings.Join(rest[2:], "/"), true
+				}
+				return "", "", "", false
+			},
+			archiveURL: func(owner, repo, ref string) string {
+				r := ref
+				if r == "" {
+					r = "HEAD"
+				}
+				return "https://codeberg.org/" + owner + "/" + repo + "/archive/" + r + ".zip"
+			},
+		},
+	}
+)
+
+// SetRepoHostForTest registers a host rewriter so tests can route short URLs
+// at an httptest.Server. Use only from tests; the returned function restores
+// the previous registration. The test parser accepts the simple
+// "/owner/repo" shape (no ref segment).
+func SetRepoHostForTest(host string, archiveURL func(owner, repo, ref string) string) func() {
+	host = strings.ToLower(host)
+	repoHostsMu.Lock()
+	prev, existed := repoHosts[host]
+	repoHosts[host] = repoRewriter{
+		parse: func(parts []string) (string, string, string, bool) {
+			if len(parts) < 2 {
+				return "", "", "", false
+			}
+			return parts[0], trimRepo(parts[1]), "", true
+		},
+		archiveURL: archiveURL,
+	}
+	repoHostsMu.Unlock()
+	return func() {
+		repoHostsMu.Lock()
+		defer repoHostsMu.Unlock()
+		if existed {
+			repoHosts[host] = prev
+		} else {
+			delete(repoHosts, host)
+		}
+	}
+}

--- a/pkg/lx/sources/repo_url_test.go
+++ b/pkg/lx/sources/repo_url_test.go
@@ -1,0 +1,65 @@
+package sources
+
+import "testing"
+
+func TestRewriteRepoURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+		ok   bool
+	}{
+		{"github short", "github.com/a/b", "https://github.com/a/b/archive/HEAD.zip", true},
+		{"github https", "https://github.com/a/b", "https://github.com/a/b/archive/HEAD.zip", true},
+		{"github http", "http://github.com/a/b", "https://github.com/a/b/archive/HEAD.zip", true},
+		{"github trailing slash", "https://github.com/a/b/", "https://github.com/a/b/archive/HEAD.zip", true},
+		{"github .git", "https://github.com/a/b.git", "https://github.com/a/b/archive/HEAD.zip", true},
+		{"github tree ref", "https://github.com/a/b/tree/dev", "https://github.com/a/b/archive/refs/heads/dev.zip", true},
+		{"github case-insensitive host", "GitHub.com/a/b", "https://github.com/a/b/archive/HEAD.zip", true},
+
+		{"gitlab short", "gitlab.com/a/b", "https://gitlab.com/a/b/-/archive/HEAD/b-HEAD.zip", true},
+		{"gitlab tree ref", "https://gitlab.com/a/b/-/tree/dev", "https://gitlab.com/a/b/-/archive/dev/b-dev.zip", true},
+
+		{"github tree slashed ref", "https://github.com/a/b/tree/feat/x", "https://github.com/a/b/archive/refs/heads/feat/x.zip", true},
+		{"github repo named get", "github.com/a/get", "https://github.com/a/get/archive/HEAD.zip", true},
+		{"github repo named archive", "github.com/a/archive", "https://github.com/a/archive/archive/HEAD.zip", true},
+		{"github repo named tree", "github.com/a/tree", "https://github.com/a/tree/archive/HEAD.zip", true},
+
+		{"gitlab subgroup", "gitlab.com/group/sub/proj", "https://gitlab.com/group/sub/proj/-/archive/HEAD/proj-HEAD.zip", true},
+		{"gitlab subgroup tree ref", "https://gitlab.com/group/sub/proj/-/tree/dev", "https://gitlab.com/group/sub/proj/-/archive/dev/proj-dev.zip", true},
+		{"gitlab repo named archive", "gitlab.com/a/archive", "https://gitlab.com/a/archive/-/archive/HEAD/archive-HEAD.zip", true},
+
+		{"bitbucket short", "bitbucket.org/a/b", "https://bitbucket.org/a/b/get/HEAD.zip", true},
+		{"bitbucket src ref", "https://bitbucket.org/a/b/src/dev", "https://bitbucket.org/a/b/get/dev.zip", true},
+		{"bitbucket src slashed ref", "https://bitbucket.org/a/b/src/feat/x", "https://bitbucket.org/a/b/get/feat/x.zip", true},
+		{"bitbucket repo named archive", "bitbucket.org/a/archive", "https://bitbucket.org/a/archive/get/HEAD.zip", true},
+
+		{"codeberg short", "codeberg.org/a/b", "https://codeberg.org/a/b/archive/HEAD.zip", true},
+		{"codeberg src/branch ref", "https://codeberg.org/a/b/src/branch/dev", "https://codeberg.org/a/b/archive/dev.zip", true},
+		{"codeberg src/branch slashed ref", "https://codeberg.org/a/b/src/branch/feat/x", "https://codeberg.org/a/b/archive/feat/x.zip", true},
+
+		// Negative cases
+		{"unknown host", "https://example.com/a/b", "", false},
+		{"missing repo", "github.com/a", "", false},
+		{"empty", "", "", false},
+		{"deep github path leave alone", "https://github.com/a/b/blob/main/x.go", "", false},
+		{"already archive zip", "https://github.com/a/b/archive/HEAD.zip", "", false},
+		{"already archive tar.gz", "https://github.com/a/b/archive/refs/heads/main.tar.gz", "", false},
+		{"github releases", "https://github.com/a/b/releases", "", false},
+		{"gitlab archive passthrough", "https://gitlab.com/a/b/-/archive/main/b-main.zip", "", false},
+		{"bitbucket get passthrough", "https://bitbucket.org/a/b/get/HEAD.zip", "", false},
+		{"non-http scheme", "ftp://github.com/a/b", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := RewriteRepoURL(tt.in)
+			if ok != tt.ok {
+				t.Fatalf("ok = %v, want %v (got %q)", ok, tt.ok, got)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Pasting github.com/owner/repo (or the equivalent on GitLab, Bitbucket, Codeberg) now auto-rewrites to the host's archive zip and expands it without needing -Z. Scheme optional. URLs already pointing at an archive are left alone.