### PR TITLE
prefer shallower -P prompt matches over deeper ones

### DIFF
--- a/cmd/lx/golden_promptlib_test.go
+++ b/cmd/lx/golden_promptlib_test.go
@@ -13,5 +13,8 @@ func TestGoldenPromptLib(t *testing.T) {
 		{name: "805_promptlib_path_relative", args: []string{"-P", "./prompts/refactor.md", "main.go"}},
 		{name: "806_promptlib_not_found", args: []string{"-P", "missing", "main.go"}},
 		{name: "807_promptlib_with_section", args: []string{"-P", "go/test", "-s", "Code", "main.go"}},
+		{name: "808_promptlib_shallower_wins", args: []string{"-P", "test", "main.go"}},
+		{name: "809_promptlib_ambiguous_same_level", args: []string{"-P", "dup", "main.go"}},
+		{name: "810_promptlib_shallower_nested_wins", args: []string{"-P", "note", "main.go"}},
 	})
 }

--- a/cmd/lx/goldenfixtures/promptlib.go
+++ b/cmd/lx/goldenfixtures/promptlib.go
@@ -16,6 +16,11 @@ func SetupPromptLibFixture(t *testing.T) string {
 	writeFile(t, dir, "prompts/go/test.md", "Write table-driven tests for the Greeter type.\n", 0644)
 	writeFile(t, dir, "prompts/refactor.md", "Refactor for readability without changing behavior.\n", 0644)
 	writeFile(t, dir, "prompts/plan.txt", "Outline a step-by-step plan first.\n", 0644)
+	writeFile(t, dir, "prompts/test.md", "Top-level test prompt.\n", 0644)
+	writeFile(t, dir, "prompts/a/dup.md", "First duplicate.\n", 0644)
+	writeFile(t, dir, "prompts/b/dup.md", "Second duplicate.\n", 0644)
+	writeFile(t, dir, "prompts/area/note.md", "Shallow nested note.\n", 0644)
+	writeFile(t, dir, "prompts/area/sub/note.md", "Deeper nested note.\n", 0644)
 
 	t.Setenv("LX_PROMPTS_DIR", filepath.Join(dir, "prompts"))
 

--- a/cmd/lx/testdata/golden/806_promptlib_not_found.golden
+++ b/cmd/lx/testdata/golden/806_promptlib_not_found.golden
@@ -2,8 +2,13 @@
 
 
 --- STDERR ---
+  a/dup.md
+  area/note.md
+  area/sub/note.md
+  b/dup.md
   go/test.md
   plan.txt
   refactor.md
+  test.md
 CLI Error: prompt "missing" not found in /ROOT/prompts
 available prompts:

--- a/cmd/lx/testdata/golden/808_promptlib_shallower_wins.golden
+++ b/cmd/lx/testdata/golden/808_promptlib_shallower_wins.golden
@@ -1,0 +1,13 @@
+--- STDOUT ---
+Top-level test prompt.
+
+
+main.go (2 rows)
+---
+```go
+package main
+func main() {}
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/809_promptlib_ambiguous_same_level.golden
+++ b/cmd/lx/testdata/golden/809_promptlib_ambiguous_same_level.golden
@@ -1,0 +1,7 @@
+--- STDOUT ---
+
+
+--- STDERR ---
+  a/dup.md
+  b/dup.md
+CLI Error: prompt "dup" is ambiguous in /ROOT/prompts; candidates:

--- a/cmd/lx/testdata/golden/810_promptlib_shallower_nested_wins.golden
+++ b/cmd/lx/testdata/golden/810_promptlib_shallower_nested_wins.golden
@@ -1,0 +1,13 @@
+--- STDOUT ---
+Shallow nested note.
+
+
+main.go (2 rows)
+---
+```go
+package main
+func main() {}
+```
+
+
+--- STDERR ---

--- a/internal/cli/prompts.go
+++ b/internal/cli/prompts.go
@@ -94,24 +94,24 @@ func (r *promptResolver) resolve(value string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	switch len(matches) {
-	case 1:
-		return matches[0], nil
-	case 0:
+	if len(matches) == 0 {
 		all, _ := r.listLib(libDir)
 		return "", fmt.Errorf("prompt %q not found in %s%s", value, libDir, suggestList(all))
-	default:
-		rels := make([]string, 0, len(matches))
-		for _, m := range matches {
-			if rel, err := filepath.Rel(libDir, m); err == nil {
-				rels = append(rels, rel)
-			} else {
-				rels = append(rels, m)
-			}
-		}
-		sort.Strings(rels)
-		return "", fmt.Errorf("prompt %q is ambiguous in %s; candidates:\n  %s", value, libDir, strings.Join(rels, "\n  "))
 	}
+	shallowest := pickShallowest(libDir, matches)
+	if len(shallowest) == 1 {
+		return shallowest[0], nil
+	}
+	rels := make([]string, 0, len(shallowest))
+	for _, m := range shallowest {
+		if rel, err := filepath.Rel(libDir, m); err == nil {
+			rels = append(rels, filepath.ToSlash(rel))
+		} else {
+			rels = append(rels, m)
+		}
+	}
+	sort.Strings(rels)
+	return "", fmt.Errorf("prompt %q is ambiguous in %s; candidates:\n  %s", value, libDir, strings.Join(rels, "\n  "))
 }
 
 func (r *promptResolver) searchLib(libDir, value string) ([]string, error) {
@@ -149,6 +149,32 @@ func (r *promptResolver) searchLib(libDir, value string) ([]string, error) {
 		return nil
 	})
 	return matches, err
+}
+
+func pickShallowest(libDir string, matches []string) []string {
+	if len(matches) <= 1 {
+		return matches
+	}
+	minDepth := -1
+	depths := make([]int, len(matches))
+	for i, m := range matches {
+		rel, err := filepath.Rel(libDir, m)
+		if err != nil {
+			rel = m
+		}
+		d := strings.Count(filepath.ToSlash(rel), "/")
+		depths[i] = d
+		if minDepth == -1 || d < minDepth {
+			minDepth = d
+		}
+	}
+	out := matches[:0:0]
+	for i, m := range matches {
+		if depths[i] == minDepth {
+			out = append(out, m)
+		}
+	}
+	return out
 }
 
 func (r *promptResolver) listLib(libDir string) ([]string, error) {


### PR DESCRIPTION
Shallower matches now win when -P resolves to multiple files; ambiguity only errors when candidates share the minimum depth.