### PR TITLE
feat: improve token estimation with character-class heuristic

### DIFF
--- a/pkg/lx/core/token.go
+++ b/pkg/lx/core/token.go
@@ -2,16 +2,153 @@ package core
 
 import "fmt"
 
-// DefaultTokenCounter returns rough estimate at ~4 bytes per token.
+const (
+	sampleThreshold = 256 * 1024
+	sampleHead      = 128 * 1024
+	sampleTail      = 64 * 1024
+)
+
+// DefaultTokenCounter estimates BPE tokens from content using a character-class
+// scanner. Auto-adapts to content shape (prose ~bytes/4, code ~bytes/3.2,
+// JSON ~bytes/2.7) without needing a language hint or embedded vocabulary.
 func DefaultTokenCounter(size int64, content interface{}) int64 {
-	var targetSize int64 = size
 	switch v := content.(type) {
 	case string:
-		targetSize = int64(len(v))
+		return estimateString(v, size)
 	case []byte:
-		targetSize = int64(len(v))
+		return estimateBytes(v, size)
 	case fmt.Stringer:
-		targetSize = int64(len(v.String()))
+		return estimateString(v.String(), size)
 	}
-	return targetSize / 4
+	return size / 4
+}
+
+func estimateString(s string, size int64) int64 {
+	n := int64(len(s))
+	if n == 0 {
+		return size / 4
+	}
+	if n <= sampleThreshold {
+		return scanString(s)
+	}
+	headEnd := sampleHead
+	tailStart := len(s) - sampleTail
+	if tailStart < headEnd {
+		return scanString(s)
+	}
+	sampleTokens := scanString(s[:headEnd]) + scanString(s[tailStart:])
+	sampleBytes := int64(headEnd + sampleTail)
+	return sampleTokens * n / sampleBytes
+}
+
+func estimateBytes(b []byte, size int64) int64 {
+	n := int64(len(b))
+	if n == 0 {
+		return size / 4
+	}
+	if n <= sampleThreshold {
+		return scanBytes(b)
+	}
+	headEnd := sampleHead
+	tailStart := len(b) - sampleTail
+	if tailStart < headEnd {
+		return scanBytes(b)
+	}
+	sampleTokens := scanBytes(b[:headEnd]) + scanBytes(b[tailStart:])
+	sampleBytes := int64(headEnd + sampleTail)
+	return sampleTokens * n / sampleBytes
+}
+
+func scanString(s string) int64 {
+	var (
+		wordRuns, wordChars, symbols, wsRuns, newlines, nonAscii int64
+		inWord, inWS                                             bool
+	)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 0x80:
+			nonAscii++
+			inWord, inWS = false, false
+		case isWord(c):
+			if !inWord {
+				wordRuns++
+				inWord = true
+			}
+			wordChars++
+			inWS = false
+		case c == '\n':
+			newlines++
+			inWord, inWS = false, false
+		case isWS(c):
+			if !inWS {
+				wsRuns++
+				inWS = true
+			}
+			inWord = false
+		default:
+			symbols++
+			inWord, inWS = false, false
+		}
+	}
+	return combine(wordRuns, wordChars, symbols, wsRuns, newlines, nonAscii)
+}
+
+func scanBytes(b []byte) int64 {
+	var (
+		wordRuns, wordChars, symbols, wsRuns, newlines, nonAscii int64
+		inWord, inWS                                             bool
+	)
+	for _, c := range b {
+		switch {
+		case c >= 0x80:
+			nonAscii++
+			inWord, inWS = false, false
+		case isWord(c):
+			if !inWord {
+				wordRuns++
+				inWord = true
+			}
+			wordChars++
+			inWS = false
+		case c == '\n':
+			newlines++
+			inWord, inWS = false, false
+		case isWS(c):
+			if !inWS {
+				wsRuns++
+				inWS = true
+			}
+			inWord = false
+		default:
+			symbols++
+			inWord, inWS = false, false
+		}
+	}
+	return combine(wordRuns, wordChars, symbols, wsRuns, newlines, nonAscii)
+}
+
+func isWord(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
+}
+
+func isWS(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\r' || c == '\v' || c == '\f'
+}
+
+// combine implements: wordRuns + max(0,(wordChars-wordRuns*4)/4)
+//   + 0.55*symbols + 0.30*wsRuns + newlines + 0.50*nonAscii
+// Done in integer arithmetic via *100 / 100.
+func combine(wordRuns, wordChars, symbols, wsRuns, newlines, nonAscii int64) int64 {
+	extraWord := wordChars - wordRuns*4
+	if extraWord < 0 {
+		extraWord = 0
+	}
+	hundredths := wordRuns*100 +
+		(extraWord*100)/4 +
+		symbols*55 +
+		wsRuns*30 +
+		newlines*100 +
+		nonAscii*50
+	return hundredths / 100
 }

--- a/pkg/lx/core/token_test.go
+++ b/pkg/lx/core/token_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -8,51 +9,21 @@ type mockStringer string
 
 func (m mockStringer) String() string { return string(m) }
 
-func TestDefaultTokenCounter(t *testing.T) {
+func TestDefaultTokenCounter_Basic(t *testing.T) {
 	tests := []struct {
 		name    string
 		size    int64
 		content interface{}
 		want    int64
 	}{
-		{
-			name:    "Exact String (4 chars)",
-			size:    4,
-			content: "1234",
-			want:    1,
-		},
-		{
-			name:    "Exact String (8 chars)",
-			size:    8,
-			content: "12345678",
-			want:    2,
-		},
-		{
-			name:    "Under 4 chars",
-			size:    3,
-			content: "123",
-			want:    0,
-		},
-		{
-			name:    "Byte Slice",
-			size:    100,
-			content: make([]byte, 8),
-			want:    2,
-		},
-		{
-			name:    "Stringer Interface",
-			size:    100,
-			content: mockStringer("1234"),
-			want:    1,
-		},
-		{
-			name:    "Nil Content (Use Size)",
-			size:    12,
-			content: nil,
-			want:    3,
-		},
+		{"single word 4 chars", 4, "1234", 1},
+		{"single word 8 chars splits", 8, "12345678", 2},
+		{"short word still costs 1", 3, "abc", 1},
+		{"stringer", 100, mockStringer("1234"), 1},
+		{"nil falls back to size/4", 12, nil, 3},
+		{"empty string falls back to size/4", 16, "", 4},
+		{"unknown type falls back to size/4", 40, 12345, 10},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := DefaultTokenCounter(tt.size, tt.content)
@@ -60,5 +31,90 @@ func TestDefaultTokenCounter(t *testing.T) {
 				t.Errorf("DefaultTokenCounter() = %d, want %d", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDefaultTokenCounter_CodeDenserThanProse(t *testing.T) {
+	prose := strings.Repeat("the quick brown fox jumps over the lazy dog ", 20)
+	code := strings.Repeat("if (x == y) { return foo(bar, baz); }\n", 20)
+
+	proseTokens := DefaultTokenCounter(int64(len(prose)), prose)
+	codeTokens := DefaultTokenCounter(int64(len(code)), code)
+
+	proseRatio := float64(len(prose)) / float64(proseTokens)
+	codeRatio := float64(len(code)) / float64(codeTokens)
+
+	if proseRatio < 3.5 || proseRatio > 4.5 {
+		t.Errorf("prose chars/token = %.2f, want ~4.0", proseRatio)
+	}
+	if codeRatio > 3.6 {
+		t.Errorf("code chars/token = %.2f, want < 3.6 (denser than prose)", codeRatio)
+	}
+	if codeTokens <= proseTokens*int64(len(code))/int64(len(prose)) {
+		// nothing — handled by ratio checks
+	}
+}
+
+func TestDefaultTokenCounter_JSONDenseSymbols(t *testing.T) {
+	json := strings.Repeat(`{"a":1,"b":[true,false,null],"c":"x"},`, 20)
+	tokens := DefaultTokenCounter(int64(len(json)), json)
+	ratio := float64(len(json)) / float64(tokens)
+	if ratio > 3.2 {
+		t.Errorf("json chars/token = %.2f, want < 3.2", ratio)
+	}
+}
+
+func TestDefaultTokenCounter_LongIdentifierSplits(t *testing.T) {
+	short := DefaultTokenCounter(4, "abcd")
+	long := DefaultTokenCounter(40, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJ1234")
+	if long <= short {
+		t.Errorf("long identifier (%d) should split into more tokens than short (%d)", long, short)
+	}
+	if long < 5 {
+		t.Errorf("40-char identifier produced only %d tokens, want >= 5", long)
+	}
+}
+
+func TestDefaultTokenCounter_NonAsciiSurcharge(t *testing.T) {
+	ascii := "hello world hello world"
+	utf8 := "héllo wörld héllo wörld"
+	a := DefaultTokenCounter(int64(len(ascii)), ascii)
+	u := DefaultTokenCounter(int64(len(utf8)), utf8)
+	if u <= a {
+		t.Errorf("utf-8 string (%d tokens) should cost >= ascii equivalent (%d tokens)", u, a)
+	}
+}
+
+func TestDefaultTokenCounter_ByteSliceMatchesString(t *testing.T) {
+	s := "package main\n\nfunc main() { println(\"hi\") }\n"
+	fromString := DefaultTokenCounter(int64(len(s)), s)
+	fromBytes := DefaultTokenCounter(int64(len(s)), []byte(s))
+	if fromString != fromBytes {
+		t.Errorf("string=%d bytes=%d, want equal", fromString, fromBytes)
+	}
+}
+
+func TestDefaultTokenCounter_LargeContentSampling(t *testing.T) {
+	// Build a >256 KiB code-like buffer so the sampling path triggers.
+	unit := "func add(a, b int) int { return a + b }\n"
+	var sb strings.Builder
+	for sb.Len() < sampleThreshold+64*1024 {
+		sb.WriteString(unit)
+	}
+	full := sb.String()
+
+	sampled := DefaultTokenCounter(int64(len(full)), full)
+
+	// Same content scanned without sampling: feed it as a slice that's exactly
+	// the content but invoke the inner scanner directly via a sub-threshold split.
+	exact := scanString(full)
+
+	diff := sampled - exact
+	if diff < 0 {
+		diff = -diff
+	}
+	tolerance := exact / 20 // 5%
+	if diff > tolerance {
+		t.Errorf("sampled=%d exact=%d diff=%d > tolerance=%d", sampled, exact, diff, tolerance)
 	}
 }


### PR DESCRIPTION
Replaces the bytes/4 token estimator with a character-class scanner counting word runs, symbols, whitespace, and newlines. Code and JSON now estimate denser than prose, closing the rough 25-40% under-count for source. Large inputs use head and tail sampling. Public signatures unchanged.