### PR TITLE
fix: report original row count in skeleton mode

### DIFF
--- a/cmd/lx/testdata/golden/300_skeleton_go_functions.golden
+++ b/cmd/lx/testdata/golden/300_skeleton_go_functions.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.go (8 rows, function signatures)
+skeleton/main.go (32 rows, function signatures)
 ---
 ```go
 // NewPerson creates a Person with the given name.

--- a/cmd/lx/testdata/golden/301_skeleton_go_structs.golden
+++ b/cmd/lx/testdata/golden/301_skeleton_go_structs.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.go (7 rows, type definitions)
+skeleton/main.go (32 rows, type definitions)
 ---
 ```go
 // Person represents a named individual.

--- a/cmd/lx/testdata/golden/302_skeleton_go_both.golden
+++ b/cmd/lx/testdata/golden/302_skeleton_go_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.go (16 rows, definitions)
+skeleton/main.go (32 rows, definitions)
 ---
 ```go
 // Person represents a named individual.

--- a/cmd/lx/testdata/golden/310_skeleton_python_functions.golden
+++ b/cmd/lx/testdata/golden/310_skeleton_python_functions.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.py (6 rows, function signatures)
+skeleton/main.py (31 rows, function signatures)
 ---
 ```python
 def top_level():

--- a/cmd/lx/testdata/golden/311_skeleton_python_structs.golden
+++ b/cmd/lx/testdata/golden/311_skeleton_python_structs.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.py (3 rows, type definitions)
+skeleton/main.py (31 rows, type definitions)
 ---
 ```python
 class Animal:

--- a/cmd/lx/testdata/golden/312_skeleton_python_both.golden
+++ b/cmd/lx/testdata/golden/312_skeleton_python_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.py (11 rows, definitions)
+skeleton/main.py (31 rows, definitions)
 ---
 ```python
 class Animal:

--- a/cmd/lx/testdata/golden/320_skeleton_c_functions.golden
+++ b/cmd/lx/testdata/golden/320_skeleton_c_functions.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.c (9 rows, function signatures)
+skeleton/main.c (21 rows, function signatures)
 ---
 ```c
 // Add two integers and return the sum.

--- a/cmd/lx/testdata/golden/321_skeleton_c_structs.golden
+++ b/cmd/lx/testdata/golden/321_skeleton_c_structs.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.c (5 rows, type definitions)
+skeleton/main.c (21 rows, type definitions)
 ---
 ```c
 /* 2-D point type */

--- a/cmd/lx/testdata/golden/322_skeleton_c_both.golden
+++ b/cmd/lx/testdata/golden/322_skeleton_c_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.c (14 rows, definitions)
+skeleton/main.c (21 rows, definitions)
 ---
 ```c
 /* 2-D point type */

--- a/cmd/lx/testdata/golden/323_skeleton_cpp_both.golden
+++ b/cmd/lx/testdata/golden/323_skeleton_cpp_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.cpp (13 rows, definitions)
+skeleton/main.cpp (24 rows, definitions)
 ---
 ```cpp
 // UI widget with a single integer value.

--- a/cmd/lx/testdata/golden/330_skeleton_java_structs.golden
+++ b/cmd/lx/testdata/golden/330_skeleton_java_structs.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/Main.java (6 rows, type definitions)
+skeleton/Main.java (35 rows, type definitions)
 ---
 ```java
 /**

--- a/cmd/lx/testdata/golden/331_skeleton_java_both.golden
+++ b/cmd/lx/testdata/golden/331_skeleton_java_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/Main.java (20 rows, definitions)
+skeleton/Main.java (35 rows, definitions)
 ---
 ```java
 /**

--- a/cmd/lx/testdata/golden/332_skeleton_java_functions_only.golden
+++ b/cmd/lx/testdata/golden/332_skeleton_java_functions_only.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/Main.java (0 rows, function signatures)
+skeleton/Main.java (35 rows, function signatures)
 
 
 --- STDERR ---

--- a/cmd/lx/testdata/golden/340_skeleton_rust_both.golden
+++ b/cmd/lx/testdata/golden/340_skeleton_rust_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.rs (25 rows, definitions)
+skeleton/main.rs (44 rows, definitions)
 ---
 ```rust
 /// A registered user with a public name.

--- a/cmd/lx/testdata/golden/350_skeleton_typescript_both.golden
+++ b/cmd/lx/testdata/golden/350_skeleton_typescript_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.ts (24 rows, definitions)
+skeleton/main.ts (45 rows, definitions)
 ---
 ```typescript
 /** Geometric shape contract. */

--- a/cmd/lx/testdata/golden/351_skeleton_javascript_both.golden
+++ b/cmd/lx/testdata/golden/351_skeleton_javascript_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.js (15 rows, definitions)
+skeleton/main.js (27 rows, definitions)
 ---
 ```javascript
 /** A simple greeter class. */

--- a/cmd/lx/testdata/golden/352_skeleton_jsx_both.golden
+++ b/cmd/lx/testdata/golden/352_skeleton_jsx_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.jsx (13 rows, definitions)
+skeleton/main.jsx (24 rows, definitions)
 ---
 ```jsx
 /* Card component with a title. */

--- a/cmd/lx/testdata/golden/353_skeleton_tsx_both.golden
+++ b/cmd/lx/testdata/golden/353_skeleton_tsx_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.tsx (20 rows, definitions)
+skeleton/main.tsx (38 rows, definitions)
 ---
 ```tsx
 /** Props accepted by Panel. */

--- a/cmd/lx/testdata/golden/360_skeleton_kotlin_both.golden
+++ b/cmd/lx/testdata/golden/360_skeleton_kotlin_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.kt (29 rows, definitions)
+skeleton/main.kt (47 rows, definitions)
 ---
 ```kotlin
 /** Immutable 2-D point. */

--- a/cmd/lx/testdata/golden/361_skeleton_ruby_both.golden
+++ b/cmd/lx/testdata/golden/361_skeleton_ruby_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.rb (14 rows, definitions)
+skeleton/main.rb (37 rows, definitions)
 ---
 ```ruby
 # Animal with a name and a maximum count.

--- a/cmd/lx/testdata/golden/370_skeleton_csharp_structs.golden
+++ b/cmd/lx/testdata/golden/370_skeleton_csharp_structs.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.cs (10 rows, type definitions)
+skeleton/main.cs (35 rows, type definitions)
 ---
 ```csharp
 /// <summary>Geometric shape contract.</summary>

--- a/cmd/lx/testdata/golden/371_skeleton_csharp_both.golden
+++ b/cmd/lx/testdata/golden/371_skeleton_csharp_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.cs (21 rows, definitions)
+skeleton/main.cs (35 rows, definitions)
 ---
 ```csharp
 /// <summary>Geometric shape contract.</summary>

--- a/cmd/lx/testdata/golden/372_skeleton_csharp_functions_only.golden
+++ b/cmd/lx/testdata/golden/372_skeleton_csharp_functions_only.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.cs (0 rows, function signatures)
+skeleton/main.cs (35 rows, function signatures)
 
 
 --- STDERR ---

--- a/cmd/lx/testdata/golden/380_skeleton_swift_structs.golden
+++ b/cmd/lx/testdata/golden/380_skeleton_swift_structs.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.swift (12 rows, type definitions)
+skeleton/main.swift (41 rows, type definitions)
 ---
 ```swift
 /// Geometric shape contract.

--- a/cmd/lx/testdata/golden/381_skeleton_swift_both.golden
+++ b/cmd/lx/testdata/golden/381_skeleton_swift_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.swift (23 rows, definitions)
+skeleton/main.swift (41 rows, definitions)
 ---
 ```swift
 /// Geometric shape contract.

--- a/cmd/lx/testdata/golden/390_skeleton_scala_structs.golden
+++ b/cmd/lx/testdata/golden/390_skeleton_scala_structs.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.scala (16 rows, type definitions)
+skeleton/main.scala (37 rows, type definitions)
 ---
 ```scala
 /** Geometric shape abstraction. */

--- a/cmd/lx/testdata/golden/391_skeleton_scala_both.golden
+++ b/cmd/lx/testdata/golden/391_skeleton_scala_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.scala (28 rows, definitions)
+skeleton/main.scala (37 rows, definitions)
 ---
 ```scala
 /** Geometric shape abstraction. */

--- a/cmd/lx/testdata/golden/392_skeleton_php_structs.golden
+++ b/cmd/lx/testdata/golden/392_skeleton_php_structs.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.php (10 rows, type definitions)
+skeleton/main.php (41 rows, type definitions)
 ---
 ```php
 /** Geometric shape contract. */

--- a/cmd/lx/testdata/golden/393_skeleton_php_both.golden
+++ b/cmd/lx/testdata/golden/393_skeleton_php_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.php (23 rows, definitions)
+skeleton/main.php (41 rows, definitions)
 ---
 ```php
 /** Geometric shape contract. */

--- a/cmd/lx/testdata/golden/394_skeleton_interleaved_reset.golden
+++ b/cmd/lx/testdata/golden/394_skeleton_interleaved_reset.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-[1/2] skeleton/main.py (11 rows, definitions)
+[1/2] skeleton/main.py (31 rows, definitions)
 ---
 ```python
 class Animal:
@@ -15,7 +15,7 @@ def create(
 ) -> "Animal":
 ```
 
-[2/2] skeleton/main.py (6 rows, function signatures)
+[2/2] skeleton/main.py (31 rows, function signatures)
 ---
 ```python
 def top_level():

--- a/cmd/lx/testdata/golden/395_skeleton_toggle_off.golden
+++ b/cmd/lx/testdata/golden/395_skeleton_toggle_off.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-[1/2] skeleton/main.go (16 rows, definitions)
+[1/2] skeleton/main.go (32 rows, definitions)
 ---
 ```go
 // Person represents a named individual.

--- a/cmd/lx/testdata/golden/396_skeleton_go_both_xml.golden
+++ b/cmd/lx/testdata/golden/396_skeleton_go_both_xml.golden
@@ -1,6 +1,6 @@
 --- STDOUT ---
 <content>
-  <document index="1" language="go" rows="16" skeleton="definitions">
+  <document index="1" language="go" rows="32" skeleton="definitions">
     <source>skeleton/main.go</source>
     <document_content>
 // Person represents a named individual.

--- a/cmd/lx/testdata/golden/397_skeleton_go_both_html.golden
+++ b/cmd/lx/testdata/golden/397_skeleton_go_both_html.golden
@@ -49,7 +49,7 @@ article > header {
 <article id="file-1">
 <header>
  <a href="#file-1" aria-label="Link to this file"><strong>skeleton/main.go</strong></a>
- <small>(16 rows)</small>
+ <small>(32 rows)</small>
 </header>
 <pre><code class="language-go">
 // Person represents a named individual.

--- a/cmd/lx/testdata/golden/400_skeleton_lines_go_both.golden
+++ b/cmd/lx/testdata/golden/400_skeleton_lines_go_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.go (16 rows, definitions)
+skeleton/main.go (32 rows, definitions)
 ---
 ```go
 // Person represents a named individual.

--- a/cmd/lx/testdata/golden/401_skeleton_head_go_both.golden
+++ b/cmd/lx/testdata/golden/401_skeleton_head_go_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.go (16 rows, definitions)
+skeleton/main.go (32 rows, definitions)
 ---
 ```go
 // Person represents a named individual.

--- a/cmd/lx/testdata/golden/402_skeleton_tail_go_both.golden
+++ b/cmd/lx/testdata/golden/402_skeleton_tail_go_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.go (16 rows, definitions)
+skeleton/main.go (32 rows, definitions)
 ---
 ```go
 ) Person {

--- a/cmd/lx/testdata/golden/403_skeleton_head_tail_go_both.golden
+++ b/cmd/lx/testdata/golden/403_skeleton_head_tail_go_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.go (16 rows, definitions)
+skeleton/main.go (32 rows, definitions)
 ---
 ```go
 ) Person {

--- a/cmd/lx/testdata/golden/404_skeleton_progressive_lines_head_tail.golden
+++ b/cmd/lx/testdata/golden/404_skeleton_progressive_lines_head_tail.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-[1/3] skeleton/main.go (16 rows, definitions)
+[1/3] skeleton/main.go (32 rows, definitions)
 ---
 ```go
 // Person represents a named individual.

--- a/cmd/lx/testdata/golden/410_skeleton_lines_python_both.golden
+++ b/cmd/lx/testdata/golden/410_skeleton_lines_python_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.py (11 rows, definitions)
+skeleton/main.py (31 rows, definitions)
 ---
 ```python
 class Animal:

--- a/cmd/lx/testdata/golden/411_skeleton_head_cpp_both.golden
+++ b/cmd/lx/testdata/golden/411_skeleton_head_cpp_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.cpp (13 rows, definitions)
+skeleton/main.cpp (24 rows, definitions)
 ---
 ```cpp
 // UI widget with a single integer value.

--- a/cmd/lx/testdata/golden/412_skeleton_tail_java_both.golden
+++ b/cmd/lx/testdata/golden/412_skeleton_tail_java_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/Main.java (20 rows, definitions)
+skeleton/Main.java (35 rows, definitions)
 ---
 ```java
     ) {

--- a/cmd/lx/testdata/golden/420_skeleton_lines_after_reset.golden
+++ b/cmd/lx/testdata/golden/420_skeleton_lines_after_reset.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.py (11 rows, definitions)
+skeleton/main.py (31 rows, definitions)
 ---
 ```python
 class Animal:

--- a/cmd/lx/testdata/golden/430_skeleton_head_swift_both.golden
+++ b/cmd/lx/testdata/golden/430_skeleton_head_swift_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.swift (23 rows, definitions)
+skeleton/main.swift (41 rows, definitions)
 ---
 ```swift
 /// Geometric shape contract.

--- a/cmd/lx/testdata/golden/431_skeleton_tail_scala_both.golden
+++ b/cmd/lx/testdata/golden/431_skeleton_tail_scala_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.scala (28 rows, definitions)
+skeleton/main.scala (37 rows, definitions)
 ---
 ```scala
     y: Int,

--- a/cmd/lx/testdata/golden/432_skeleton_lines_php_both.golden
+++ b/cmd/lx/testdata/golden/432_skeleton_lines_php_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.php (23 rows, definitions)
+skeleton/main.php (41 rows, definitions)
 ---
 ```php
 /** Geometric shape contract. */

--- a/cmd/lx/testdata/golden/433_skeleton_lines_jsx_both.golden
+++ b/cmd/lx/testdata/golden/433_skeleton_lines_jsx_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.jsx (13 rows, definitions)
+skeleton/main.jsx (24 rows, definitions)
 ---
 ```jsx
 /* Card component with a title. */

--- a/cmd/lx/testdata/golden/434_skeleton_head_tsx_both.golden
+++ b/cmd/lx/testdata/golden/434_skeleton_head_tsx_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.tsx (20 rows, definitions)
+skeleton/main.tsx (38 rows, definitions)
 ---
 ```tsx
 /** Props accepted by Panel. */

--- a/cmd/lx/testdata/golden/435_skeleton_lines_numbered_go_both.golden
+++ b/cmd/lx/testdata/golden/435_skeleton_lines_numbered_go_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.go (16 rows, definitions)
+skeleton/main.go (32 rows, definitions)
 ---
 ```go
  1: // Person represents a named individual.

--- a/cmd/lx/testdata/golden/436_skeleton_head_numbered_swift_both.golden
+++ b/cmd/lx/testdata/golden/436_skeleton_head_numbered_swift_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.swift (23 rows, definitions)
+skeleton/main.swift (41 rows, definitions)
 ---
 ```swift
  1: /// Geometric shape contract.

--- a/cmd/lx/testdata/golden/500_skeleton_dart_functions.golden
+++ b/cmd/lx/testdata/golden/500_skeleton_dart_functions.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.dart (7 rows, function signatures)
+skeleton/main.dart (30 rows, function signatures)
 ---
 ```dart
 /* Greet a person by name. */

--- a/cmd/lx/testdata/golden/501_skeleton_dart_structs.golden
+++ b/cmd/lx/testdata/golden/501_skeleton_dart_structs.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.dart (6 rows, type definitions)
+skeleton/main.dart (30 rows, type definitions)
 ---
 ```dart
 /// An animal with a name and species.

--- a/cmd/lx/testdata/golden/502_skeleton_dart_both.golden
+++ b/cmd/lx/testdata/golden/502_skeleton_dart_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.dart (15 rows, definitions)
+skeleton/main.dart (30 rows, definitions)
 ---
 ```dart
 /// An animal with a name and species.

--- a/cmd/lx/testdata/golden/540_skeleton_zig_functions.golden
+++ b/cmd/lx/testdata/golden/540_skeleton_zig_functions.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.zig (7 rows, function signatures)
+skeleton/main.zig (20 rows, function signatures)
 ---
 ```zig
 /// Greet by printing a name.

--- a/cmd/lx/testdata/golden/550_skeleton_haskell_functions.golden
+++ b/cmd/lx/testdata/golden/550_skeleton_haskell_functions.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.hs (6 rows, function signatures)
+skeleton/main.hs (20 rows, function signatures)
 ---
 ```haskell
 -- | Greet by name, with a fallback.

--- a/cmd/lx/testdata/golden/551_skeleton_haskell_structs.golden
+++ b/cmd/lx/testdata/golden/551_skeleton_haskell_structs.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.hs (5 rows, type definitions)
+skeleton/main.hs (20 rows, type definitions)
 ---
 ```haskell
 -- | Animals supported by the system.

--- a/cmd/lx/testdata/golden/552_skeleton_haskell_both.golden
+++ b/cmd/lx/testdata/golden/552_skeleton_haskell_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.hs (11 rows, definitions)
+skeleton/main.hs (20 rows, definitions)
 ---
 ```haskell
 -- | Animals supported by the system.

--- a/cmd/lx/testdata/golden/560_skeleton_groovy_functions.golden
+++ b/cmd/lx/testdata/golden/560_skeleton_groovy_functions.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.groovy (6 rows, function signatures)
+skeleton/main.groovy (27 rows, function signatures)
 ---
 ```groovy
 // Standalone increment.

--- a/cmd/lx/testdata/golden/561_skeleton_groovy_structs.golden
+++ b/cmd/lx/testdata/golden/561_skeleton_groovy_structs.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.groovy (5 rows, type definitions)
+skeleton/main.groovy (27 rows, type definitions)
 ---
 ```groovy
 /** Animal with name and species. */

--- a/cmd/lx/testdata/golden/562_skeleton_groovy_both.golden
+++ b/cmd/lx/testdata/golden/562_skeleton_groovy_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.groovy (13 rows, definitions)
+skeleton/main.groovy (27 rows, definitions)
 ---
 ```groovy
 /** Animal with name and species. */

--- a/cmd/lx/testdata/golden/580_skeleton_objc_functions.golden
+++ b/cmd/lx/testdata/golden/580_skeleton_objc_functions.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.m (2 rows, function signatures)
+skeleton/main.m (20 rows, function signatures)
 ---
 ```objectivec
 // Standalone C function.

--- a/cmd/lx/testdata/golden/581_skeleton_objc_structs.golden
+++ b/cmd/lx/testdata/golden/581_skeleton_objc_structs.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.m (12 rows, type definitions)
+skeleton/main.m (20 rows, type definitions)
 ---
 ```objectivec
 /** Animal with name and species. */

--- a/cmd/lx/testdata/golden/582_skeleton_objc_both.golden
+++ b/cmd/lx/testdata/golden/582_skeleton_objc_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.m (14 rows, definitions)
+skeleton/main.m (20 rows, definitions)
 ---
 ```objectivec
 /** Animal with name and species. */

--- a/cmd/lx/testdata/golden/590_skeleton_ocaml_structs.golden
+++ b/cmd/lx/testdata/golden/590_skeleton_ocaml_structs.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.ml (19 rows, type definitions)
+skeleton/main.ml (36 rows, type definitions)
 ---
 ```ocaml
 (* Basic animal variants. *)

--- a/cmd/lx/testdata/golden/591_skeleton_ocaml_both.golden
+++ b/cmd/lx/testdata/golden/591_skeleton_ocaml_both.golden
@@ -1,5 +1,5 @@
 --- STDOUT ---
-skeleton/main.ml (26 rows, definitions)
+skeleton/main.ml (36 rows, definitions)
 ---
 ```ocaml
 (* Basic animal variants. *)

--- a/cmd/lx/testdata/golden/744_tree_content_skeleton_functions.golden
+++ b/cmd/lx/testdata/golden/744_tree_content_skeleton_functions.golden
@@ -7,9 +7,9 @@ src/
 └── app_test.go
 ```
 
-[1/3] src/app.go (0 rows, function signatures)
-[2/3] src/app_test.go (0 rows, function signatures)
-[3/3] src/sub/helper.go (0 rows, function signatures)
+[1/3] src/app.go (1 rows, function signatures)
+[2/3] src/app_test.go (1 rows, function signatures)
+[3/3] src/sub/helper.go (1 rows, function signatures)
 
 
 --- STDERR ---

--- a/pkg/lx/internal/lines.go
+++ b/pkg/lx/internal/lines.go
@@ -68,7 +68,7 @@ func (lnf LineNumberFormatter) Format(f fmt.State, c rune) {
 	}
 
 	if len(lnf.Tail) > 0 {
-		tailCount := countLines(lnf.Tail)
+		tailCount := CountLines(lnf.Tail)
 		startRow := lnf.TotalRows - tailCount + 1
 		if startRow < 1 {
 			startRow = 1
@@ -88,7 +88,7 @@ func EstimateLineCount(r io.ReaderAt, fileSize int64, buf []byte) (int, bool, er
 	}
 
 	if int64(n) >= fileSize {
-		return countLines(buf[:n]), true, nil
+		return CountLines(buf[:n]), true, nil
 	}
 
 	newlineCount := bytes.Count(buf[:n], []byte("\n"))
@@ -213,7 +213,7 @@ func AppendLine(out []byte, lines [][]byte, row int) []byte {
 	return out
 }
 
-func countLines(data []byte) int {
+func CountLines(data []byte) int {
 	if len(data) == 0 {
 		return 0
 	}

--- a/pkg/lx/render/processor.go
+++ b/pkg/lx/render/processor.go
@@ -204,9 +204,11 @@ func (p *Processor) prepareFileContext(file sources.InputFile, index int, scratc
 	cfg := file.Config
 
 	var skeletonMode string
+	originalRows := -1
 	if !isBinary && !isImage && (cfg.SkeletonFunctions || cfg.SkeletonTypes) && skeleton.Supported(lang) {
 		allData := make([]byte, size)
 		if _, err := reader.ReadAt(allData, 0); err == nil {
+			originalRows = internal.CountLines(allData)
 			filtered := skeleton.Extract(lang, allData, cfg.SkeletonFunctions, cfg.SkeletonTypes)
 			reader = bytes.NewReader(filtered)
 			size = int64(len(filtered))
@@ -227,6 +229,13 @@ func (p *Processor) prepareFileContext(file sources.InputFile, index int, scratc
 
 	isCompact := (cfg.Head == 0 && cfg.Tail == 0) || isBinary || size == 0
 	totalRows, exact, _ := internal.EstimateLineCount(reader, size, scratch)
+
+	// In skeleton mode the header should report the original file's row
+	// count, not the filtered output's; slicing still uses totalRows.
+	displayRows, displayExact := totalRows, exact
+	if originalRows >= 0 {
+		displayRows, displayExact = originalRows, true
+	}
 
 	var contentData interface{}
 	if !isBinary && !isCompact && size > 0 && !isImage {
@@ -256,8 +265,8 @@ func (p *Processor) prepareFileContext(file sources.InputFile, index int, scratc
 		Path:          file.Path,
 		AbsPath:       file.AbsPath,
 		Size:          size,
-		TotalRows:     totalRows,
-		IsEstimate:    !exact,
+		TotalRows:     displayRows,
+		IsEstimate:    !displayExact,
 		Language:      lang,
 		Content:       contentData,
 		TokenEstimate: p.tokenCounter(size, contentData),

--- a/pkg/lx/render/processor_test.go
+++ b/pkg/lx/render/processor_test.go
@@ -71,8 +71,8 @@ func C() {
 	}
 
 	got := buf.String()
-	if !strings.Contains(got, "(3 rows, function signatures)") {
-		t.Fatalf("expected filtered row count in header, got:\n%s", got)
+	if !strings.Contains(got, "(13 rows, function signatures)") {
+		t.Fatalf("expected original row count in header, got:\n%s", got)
 	}
 	if !strings.Contains(got, "... (1 rows skipped)") {
 		t.Fatalf("expected gap based on filtered rows, got:\n%s", got)


### PR DESCRIPTION
The -u/-Y skeleton filters replaced the file content before the row count was computed, so headers reported the filtered line count instead of the original file length. Count the original rows before extraction and keep the filtered count for slicing. Golden files updated.

Closes #73