### PR TITLE
feat: preserve decorators and annotations in skeleton signatures

### DIFF
--- a/cmd/lx/golden_skeleton_test.go
+++ b/cmd/lx/golden_skeleton_test.go
@@ -85,6 +85,18 @@ func TestGoldenSkeleton(t *testing.T) {
 		// 590-599: OCaml
 		{name: "590_skeleton_ocaml_structs", args: []string{"-Y", "skeleton/main.ml"}},
 		{name: "591_skeleton_ocaml_both", args: []string{"-u", "-Y", "skeleton/main.ml"}},
+
+		// 600-619: decorators / annotations
+		{name: "600_skeleton_python_decorators", args: []string{"-u", "-Y", "skeleton/deco.py"}},
+		{name: "601_skeleton_typescript_decorators", args: []string{"-u", "-Y", "skeleton/deco.ts"}},
+		{name: "602_skeleton_tsx_decorators", args: []string{"-u", "-Y", "skeleton/deco.tsx"}},
+		{name: "603_skeleton_java_annotations", args: []string{"-u", "-Y", "skeleton/Deco.java"}},
+		{name: "604_skeleton_kotlin_annotations", args: []string{"-u", "-Y", "skeleton/deco.kt"}},
+		{name: "605_skeleton_rust_attributes", args: []string{"-u", "-Y", "skeleton/deco.rs"}},
+		{name: "606_skeleton_csharp_attributes", args: []string{"-u", "-Y", "skeleton/deco.cs"}},
+		{name: "607_skeleton_scala_annotations", args: []string{"-u", "-Y", "skeleton/deco.scala"}},
+		{name: "608_skeleton_swift_attributes", args: []string{"-u", "-Y", "skeleton/deco.swift"}},
+		{name: "609_skeleton_dart_annotations", args: []string{"-u", "-Y", "skeleton/deco.dart"}},
 	})
 }
 

--- a/cmd/lx/goldenfixtures/skeleton.go
+++ b/cmd/lx/goldenfixtures/skeleton.go
@@ -37,6 +37,16 @@ func SetupSkeletonFixture(t *testing.T) string {
 		"main.groovy",
 		"main.m",
 		"main.ml",
+		"deco.py",
+		"deco.ts",
+		"deco.tsx",
+		"Deco.java",
+		"deco.kt",
+		"deco.rs",
+		"deco.cs",
+		"deco.scala",
+		"deco.swift",
+		"deco.dart",
 	}
 	for _, name := range languageFiles {
 		content := readFixtureFile(t, filepath.Join("languages", name))

--- a/cmd/lx/testdata/golden/600_skeleton_python_decorators.golden
+++ b/cmd/lx/testdata/golden/600_skeleton_python_decorators.golden
@@ -2,9 +2,12 @@
 skeleton/deco.py (12 rows, definitions)
 ---
 ```python
+@dataclass
 class Config:
     name: str
+    @property
     def label(self) -> str:
+@cache
 def load() -> Config:
 ```
 

--- a/cmd/lx/testdata/golden/600_skeleton_python_decorators.golden
+++ b/cmd/lx/testdata/golden/600_skeleton_python_decorators.golden
@@ -1,0 +1,12 @@
+--- STDOUT ---
+skeleton/deco.py (12 rows, definitions)
+---
+```python
+class Config:
+    name: str
+    def label(self) -> str:
+def load() -> Config:
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/601_skeleton_typescript_decorators.golden
+++ b/cmd/lx/testdata/golden/601_skeleton_typescript_decorators.golden
@@ -2,8 +2,10 @@
 skeleton/deco.ts (7 rows, definitions)
 ---
 ```typescript
+@Component({ selector: "app" })
 export class Widget {
     @Input() title: string = "";
+    @HostListener("click")
     onClick(): void {
 }
 ```

--- a/cmd/lx/testdata/golden/601_skeleton_typescript_decorators.golden
+++ b/cmd/lx/testdata/golden/601_skeleton_typescript_decorators.golden
@@ -1,0 +1,12 @@
+--- STDOUT ---
+skeleton/deco.ts (7 rows, definitions)
+---
+```typescript
+export class Widget {
+    @Input() title: string = "";
+    onClick(): void {
+}
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/602_skeleton_tsx_decorators.golden
+++ b/cmd/lx/testdata/golden/602_skeleton_tsx_decorators.golden
@@ -2,8 +2,10 @@
 skeleton/deco.tsx (7 rows, definitions)
 ---
 ```tsx
+@Component({ selector: "app" })
 export class Widget {
     @Input() title: string = "";
+    @HostListener("click")
     onClick(): void {
 }
 ```

--- a/cmd/lx/testdata/golden/602_skeleton_tsx_decorators.golden
+++ b/cmd/lx/testdata/golden/602_skeleton_tsx_decorators.golden
@@ -1,0 +1,12 @@
+--- STDOUT ---
+skeleton/deco.tsx (7 rows, definitions)
+---
+```tsx
+export class Widget {
+    @Input() title: string = "";
+    onClick(): void {
+}
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/603_skeleton_java_annotations.golden
+++ b/cmd/lx/testdata/golden/603_skeleton_java_annotations.golden
@@ -1,0 +1,13 @@
+--- STDOUT ---
+skeleton/Deco.java (7 rows, definitions)
+---
+```java
+@Service
+public class UserService {
+    @Override
+    public String name() {
+}
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/604_skeleton_kotlin_annotations.golden
+++ b/cmd/lx/testdata/golden/604_skeleton_kotlin_annotations.golden
@@ -1,0 +1,13 @@
+--- STDOUT ---
+skeleton/deco.kt (7 rows, definitions)
+---
+```kotlin
+@Serializable
+class User(val name: String) {
+    @Deprecated("use name")
+    fun legacy(): String {
+}
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/605_skeleton_rust_attributes.golden
+++ b/cmd/lx/testdata/golden/605_skeleton_rust_attributes.golden
@@ -1,0 +1,14 @@
+--- STDOUT ---
+skeleton/deco.rs (9 rows, definitions)
+---
+```rust
+#[derive(Debug, Clone)]
+pub struct Point {
+    pub x: i32,
+}
+#[inline]
+pub fn origin() -> Point {
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/606_skeleton_csharp_attributes.golden
+++ b/cmd/lx/testdata/golden/606_skeleton_csharp_attributes.golden
@@ -1,0 +1,14 @@
+--- STDOUT ---
+skeleton/deco.cs (6 rows, definitions)
+---
+```csharp
+[Serializable]
+public class Record
+{
+    [JsonProperty]
+    public string Name() { return "x"; }
+}
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/607_skeleton_scala_annotations.golden
+++ b/cmd/lx/testdata/golden/607_skeleton_scala_annotations.golden
@@ -1,0 +1,12 @@
+--- STDOUT ---
+skeleton/deco.scala (4 rows, definitions)
+---
+```scala
+class Service {
+    @tailrec
+    final def loop(n: Int): Int = loop(n)
+}
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/608_skeleton_swift_attributes.golden
+++ b/cmd/lx/testdata/golden/608_skeleton_swift_attributes.golden
@@ -1,0 +1,13 @@
+--- STDOUT ---
+skeleton/deco.swift (5 rows, definitions)
+---
+```swift
+@objc
+class Handler {
+    @available(iOS 13, *)
+    func handle() {}
+}
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/609_skeleton_dart_annotations.golden
+++ b/cmd/lx/testdata/golden/609_skeleton_dart_annotations.golden
@@ -1,0 +1,12 @@
+--- STDOUT ---
+skeleton/deco.dart (7 rows, definitions)
+---
+```dart
+@immutable
+class Widget {
+    String build() {
+}
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/609_skeleton_dart_annotations.golden
+++ b/cmd/lx/testdata/golden/609_skeleton_dart_annotations.golden
@@ -4,6 +4,7 @@ skeleton/deco.dart (7 rows, definitions)
 ```dart
 @immutable
 class Widget {
+    @override
     String build() {
 }
 ```

--- a/cmd/lx/testdata/languages/Deco.java
+++ b/cmd/lx/testdata/languages/Deco.java
@@ -1,0 +1,7 @@
+@Service
+public class UserService {
+    @Override
+    public String name() {
+        return "user";
+    }
+}

--- a/cmd/lx/testdata/languages/deco.cs
+++ b/cmd/lx/testdata/languages/deco.cs
@@ -1,0 +1,6 @@
+[Serializable]
+public class Record
+{
+    [JsonProperty]
+    public string Name() { return "x"; }
+}

--- a/cmd/lx/testdata/languages/deco.dart
+++ b/cmd/lx/testdata/languages/deco.dart
@@ -1,0 +1,7 @@
+@immutable
+class Widget {
+    @override
+    String build() {
+        return "x";
+    }
+}

--- a/cmd/lx/testdata/languages/deco.kt
+++ b/cmd/lx/testdata/languages/deco.kt
@@ -1,0 +1,7 @@
+@Serializable
+class User(val name: String) {
+    @Deprecated("use name")
+    fun legacy(): String {
+        return name
+    }
+}

--- a/cmd/lx/testdata/languages/deco.py
+++ b/cmd/lx/testdata/languages/deco.py
@@ -1,0 +1,12 @@
+@dataclass
+class Config:
+    name: str
+
+    @property
+    def label(self) -> str:
+        return self.name
+
+
+@cache
+def load() -> Config:
+    return Config("x")

--- a/cmd/lx/testdata/languages/deco.rs
+++ b/cmd/lx/testdata/languages/deco.rs
@@ -1,0 +1,9 @@
+#[derive(Debug, Clone)]
+pub struct Point {
+    pub x: i32,
+}
+
+#[inline]
+pub fn origin() -> Point {
+    Point { x: 0 }
+}

--- a/cmd/lx/testdata/languages/deco.scala
+++ b/cmd/lx/testdata/languages/deco.scala
@@ -1,0 +1,4 @@
+class Service {
+    @tailrec
+    final def loop(n: Int): Int = loop(n)
+}

--- a/cmd/lx/testdata/languages/deco.swift
+++ b/cmd/lx/testdata/languages/deco.swift
@@ -1,0 +1,5 @@
+@objc
+class Handler {
+    @available(iOS 13, *)
+    func handle() {}
+}

--- a/cmd/lx/testdata/languages/deco.ts
+++ b/cmd/lx/testdata/languages/deco.ts
@@ -1,0 +1,7 @@
+@Component({ selector: "app" })
+export class Widget {
+    @Input() title: string = "";
+
+    @HostListener("click")
+    onClick(): void {}
+}

--- a/cmd/lx/testdata/languages/deco.tsx
+++ b/cmd/lx/testdata/languages/deco.tsx
@@ -1,0 +1,7 @@
+@Component({ selector: "app" })
+export class Widget {
+    @Input() title: string = "";
+
+    @HostListener("click")
+    onClick(): void {}
+}

--- a/pkg/lx/skeleton/extract.go
+++ b/pkg/lx/skeleton/extract.go
@@ -91,6 +91,7 @@ func (def *langDef) processNode(node *gotreesitter.Node, out, src []byte, lines 
 	case functions && containsStr(def.funcTypes, nodeType):
 		if def.funcVisible == nil || def.funcVisible(node, src, lang) {
 			out = prependDoc(out, lines, outerStart)
+			out = langs.EmitDecorators(out, lines, outerStart, int(node.StartPoint().Row))
 			if def.emitFunc != nil {
 				out = def.emitFunc(out, src, lines, node, lang)
 			} else {
@@ -102,6 +103,7 @@ func (def *langDef) processNode(node *gotreesitter.Node, out, src []byte, lines 
 		}
 	case structs && containsStr(def.structTypes, nodeType):
 		out = prependDoc(out, lines, outerStart)
+		out = langs.EmitDecorators(out, lines, outerStart, int(node.StartPoint().Row))
 		out = def.emitStruct(out, src, lines, node, lang, functions)
 	}
 	return out

--- a/pkg/lx/skeleton/extract_test.go
+++ b/pkg/lx/skeleton/extract_test.go
@@ -424,7 +424,7 @@ func TestPython_Both(t *testing.T) {
 	}
 }
 
-func TestPython_DecoratorSkipped(t *testing.T) {
+func TestPython_DecoratorPreserved(t *testing.T) {
 	src := []byte(`class SwitchTenantRequest(BaseModel):
     tenant_id: UUID
 
@@ -443,11 +443,11 @@ async def get_logo() -> None:
 	if !strings.Contains(out, "class SwitchTenantRequest(BaseModel):") {
 		t.Errorf("expected class, got:\n%s", out)
 	}
-	if strings.Contains(out, "@router") {
-		t.Errorf("decorator should not appear:\n%s", out)
+	if !strings.Contains(out, `@router.put("/logo", status_code=status.HTTP_204_NO_CONTENT)`) {
+		t.Errorf("single-line decorator should appear:\n%s", out)
 	}
-	if strings.Contains(out, "status_code") {
-		t.Errorf("decorator args should not appear:\n%s", out)
+	if !strings.Contains(out, "@router.get(\n    \"/logo\",\n    status_code=status.HTTP_200_OK,\n)") {
+		t.Errorf("multi-line decorator should appear in full:\n%s", out)
 	}
 	if !strings.Contains(out, "async def update_logo() -> None:") {
 		t.Errorf("expected update_logo, got:\n%s", out)

--- a/pkg/lx/skeleton/langs/dart.go
+++ b/pkg/lx/skeleton/langs/dart.go
@@ -22,10 +22,10 @@ func DartEmitClass(out, src []byte, lines [][]byte, n *gotreesitter.Node, lang *
 		}
 		switch child.Type(lang) {
 		case "declaration":
-			out = EmitWithDoc(out, lines, int(child.StartPoint().Row), int(child.EndPoint().Row))
+			out = EmitWithDoc(out, lines, PrecedingAnnotationRow(body, child, i, lang), int(child.EndPoint().Row))
 		case "method_signature":
 			if functions {
-				out = EmitWithDoc(out, lines, int(child.StartPoint().Row), int(child.EndPoint().Row))
+				out = EmitWithDoc(out, lines, PrecedingAnnotationRow(body, child, i, lang), int(child.EndPoint().Row))
 			}
 		}
 	}

--- a/pkg/lx/skeleton/langs/helpers.go
+++ b/pkg/lx/skeleton/langs/helpers.go
@@ -104,8 +104,7 @@ func emitFuncSig(out []byte, lines [][]byte, n *gotreesitter.Node, lang *gotrees
 	return EmitFuncSig(out, lines, n, lang, indentBody, bodyChildType, false)
 }
 
-// EmitDecorators appends the decorator/annotation lines in [fromRow, sigRow-1],
-// i.e. the lines between an outer decorator-inclusive start and the signature.
+// EmitDecorators appends the decorator/annotation lines in [fromRow, sigRow-1].
 func EmitDecorators(out []byte, lines [][]byte, fromRow, sigRow int) []byte {
 	if fromRow < sigRow {
 		return internal.AppendLines(out, lines, fromRow, sigRow-1)
@@ -113,9 +112,8 @@ func EmitDecorators(out []byte, lines [][]byte, fromRow, sigRow int) []byte {
 	return out
 }
 
-// PrecedingAnnotationRow returns the earliest row of the contiguous
-// decorator/annotation siblings immediately preceding child (at index i in
-// body), or child's own start row when there is none.
+// PrecedingAnnotationRow returns the start row of the contiguous decorator/
+// annotation siblings before child (index i in body), or child's own start row.
 func PrecedingAnnotationRow(body, child *gotreesitter.Node, i int, lang *gotreesitter.Language) int {
 	row := int(child.StartPoint().Row)
 	for j := i - 1; j >= 0; j-- {

--- a/pkg/lx/skeleton/langs/helpers.go
+++ b/pkg/lx/skeleton/langs/helpers.go
@@ -104,6 +104,31 @@ func emitFuncSig(out []byte, lines [][]byte, n *gotreesitter.Node, lang *gotrees
 	return EmitFuncSig(out, lines, n, lang, indentBody, bodyChildType, false)
 }
 
+// EmitDecorators appends the decorator/annotation lines in [fromRow, sigRow-1],
+// i.e. the lines between an outer decorator-inclusive start and the signature.
+func EmitDecorators(out []byte, lines [][]byte, fromRow, sigRow int) []byte {
+	if fromRow < sigRow {
+		return internal.AppendLines(out, lines, fromRow, sigRow-1)
+	}
+	return out
+}
+
+// PrecedingAnnotationRow returns the earliest row of the contiguous
+// decorator/annotation siblings immediately preceding child (at index i in
+// body), or child's own start row when there is none.
+func PrecedingAnnotationRow(body, child *gotreesitter.Node, i int, lang *gotreesitter.Language) int {
+	row := int(child.StartPoint().Row)
+	for j := i - 1; j >= 0; j-- {
+		switch body.Child(j).Type(lang) {
+		case "decorator", "annotation":
+			row = int(body.Child(j).StartPoint().Row)
+		default:
+			return row
+		}
+	}
+	return row
+}
+
 func emitAllLines(out []byte, lines [][]byte, n *gotreesitter.Node) []byte {
 	return internal.AppendLines(out, lines, int(n.StartPoint().Row), int(n.EndPoint().Row))
 }

--- a/pkg/lx/skeleton/langs/python.go
+++ b/pkg/lx/skeleton/langs/python.go
@@ -47,11 +47,13 @@ func pyProcessMember(out, src []byte, lines [][]byte, n *gotreesitter.Node, lang
 			return out
 		}
 		out = EmitLeadingDoc(out, lines, outerStart)
+		out = EmitDecorators(out, lines, outerStart, int(actual.StartPoint().Row))
 		out = emitFuncSig(out, lines, actual, lang, true, "")
 		out = AppendPyDocstring(out, lines, actual, lang)
 		return out
 	case "class_definition":
 		out = EmitLeadingDoc(out, lines, outerStart)
+		out = EmitDecorators(out, lines, outerStart, int(actual.StartPoint().Row))
 		return PyEmitClass(out, src, lines, actual, lang, functions)
 	default:
 		if pyIsClassVar(n, lang) {

--- a/pkg/lx/skeleton/langs/typescript.go
+++ b/pkg/lx/skeleton/langs/typescript.go
@@ -33,7 +33,9 @@ func tsEmitClass(out, src []byte, lines [][]byte, n *gotreesitter.Node, lang *go
 			out = EmitWithDoc(out, lines, int(child.StartPoint().Row), int(child.EndPoint().Row))
 		case "method_definition":
 			if functions {
-				out = EmitLeadingDoc(out, lines, int(child.StartPoint().Row))
+				decoRow := PrecedingAnnotationRow(body, child, i, lang)
+				out = EmitLeadingDoc(out, lines, decoRow)
+				out = EmitDecorators(out, lines, decoRow, int(child.StartPoint().Row))
 				out = emitFuncSig(out, lines, child, lang, false, "")
 			}
 		}


### PR DESCRIPTION
Skeleton output dropped Python decorators and TypeScript/Dart decorators that sit above the definition line, even though languages whose grammars fold annotations into the declaration node (Java, Kotlin, Rust, C#, Scala, Swift) already kept them. This emits the decorator/annotation lines for the affected languages so the signatures carry their contract, and adds golden coverage for every language that has them. Closes #79.