### PR TITLE
fix: use content-aware token counter for stats

### DIFF
--- a/cmd/lx/testdata/golden/070_stats_forced.golden
+++ b/cmd/lx/testdata/golden/070_stats_forced.golden
@@ -8,5 +8,5 @@ func main() {}
 
 
 --- STDERR ---
-  ~15 tokens
+  ~26 tokens
 ▎ 1 file · 2 rows · 1 section · 27 B

--- a/pkg/lx/streaming/pipeline.go
+++ b/pkg/lx/streaming/pipeline.go
@@ -117,13 +117,20 @@ func (s *Stream) executePipeline(ctx context.Context, dest *byteCounter, global 
 	return totalRows, nil
 }
 
+// byteCounter counts bytes written, plus token estimates when a tokenizer is
+// set. Estimating per Write covers separators and wrappers too, not just items.
 type byteCounter struct {
-	w     io.Writer
-	count int64
+	w         io.Writer
+	count     int64
+	tokens    int64
+	tokenizer core.Tokenizer
 }
 
 func (b *byteCounter) Write(p []byte) (n int, err error) {
 	n, err = b.w.Write(p)
 	b.count += int64(n)
+	if b.tokenizer != nil && n > 0 {
+		b.tokens += b.tokenizer.Estimate(int64(n), p[:n])
+	}
 	return
 }

--- a/pkg/lx/streaming/stream.go
+++ b/pkg/lx/streaming/stream.go
@@ -17,7 +17,9 @@ type FileErrorHandler = render.FileErrorHandler
 
 type defaultTokenizer struct{}
 
-func (defaultTokenizer) Estimate(size int64, _ interface{}) int64 { return size / 4 }
+func (defaultTokenizer) Estimate(size int64, content interface{}) int64 {
+	return core.DefaultTokenCounter(size, content)
+}
 
 // Stream manages a collection of files, sections, and prompts for rendering.
 type Stream struct {
@@ -152,6 +154,7 @@ func (s *Stream) Prepare() core.GlobalContext {
 			currentSection.TotalSize += f.Size
 			global.TotalFiles++
 			global.TotalSize += f.Size
+			// Size-only: no content read yet. Execute replaces this.
 			global.TokenEstimate += s.tokenizer.Estimate(f.Size, nil)
 
 			s.prepared = append(s.prepared, render.PreparedItem{
@@ -180,7 +183,7 @@ func (s *Stream) GetGlobalContext() core.GlobalContext { return s.Prepare() }
 
 func (s *Stream) Execute(ctx context.Context, w io.Writer) error {
 	global := s.Prepare()
-	counter := &byteCounter{w: w}
+	counter := &byteCounter{w: w, tokenizer: s.tokenizer}
 
 	if err := s.engine.OutputHeader.Execute(counter, core.HeaderContext{Global: global}); err != nil {
 		return err
@@ -195,7 +198,7 @@ func (s *Stream) Execute(ctx context.Context, w io.Writer) error {
 
 	global.TotalWrittenBytes = counter.count
 	global.TotalRows = totalRows
-	global.TokenEstimate = s.tokenizer.Estimate(counter.count, nil)
+	global.TokenEstimate = counter.tokens
 	s.finalStats = &global
 	return nil
 }

--- a/pkg/lx/streaming/stream_test.go
+++ b/pkg/lx/streaming/stream_test.go
@@ -2,6 +2,7 @@ package streaming
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -154,5 +155,104 @@ func TestStream_MaxSizeUnsetKeepsEverything(t *testing.T) {
 
 	if n := stream.GetGlobalContext().TotalFiles; n != 1 {
 		t.Errorf("TotalFiles = %d, want 1", n)
+	}
+}
+
+// One token per byte, so totals can be compared against bytes exactly.
+type sizeTokenizer struct{}
+
+func (sizeTokenizer) Estimate(size int64, _ interface{}) int64 { return size }
+
+func tokenEstimateFor(t *testing.T, content string) int64 {
+	t.Helper()
+	stream, err := NewStream(core.NewConfig(), core.RunnerConfig{Head: -1})
+	if err != nil {
+		t.Fatalf("NewStream failed: %v", err)
+	}
+	stream.AddFile(sources.NewBufferInputFile("sample.txt", []byte(content)))
+
+	var buf strings.Builder
+	if err := stream.Execute(context.Background(), &buf); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	return stream.GetGlobalContext().TokenEstimate
+}
+
+func TestStream_TokenEstimateReflectsContentShape(t *testing.T) {
+	prose := strings.Repeat("hello world ", 60)
+	symbols := strings.Repeat(`{"a":1},`, 90)
+	if len(prose) != len(symbols) {
+		t.Fatalf("fixture sizes differ: %d vs %d", len(prose), len(symbols))
+	}
+
+	proseTokens := tokenEstimateFor(t, prose)
+	symbolTokens := tokenEstimateFor(t, symbols)
+
+	if symbolTokens <= proseTokens {
+		t.Errorf("symbol-dense estimate %d <= prose estimate %d, want greater for equal byte counts",
+			symbolTokens, proseTokens)
+	}
+
+	sizeOnly := int64(len(prose)) / 4
+	if proseTokens == sizeOnly && symbolTokens == sizeOnly {
+		t.Error("estimates match bytes/4 exactly, want a content-derived estimate")
+	}
+}
+
+func TestStream_TokenEstimateCoversAllEmittedBytes(t *testing.T) {
+	stream, err := NewStream(core.NewConfig(), core.RunnerConfig{Head: -1})
+	if err != nil {
+		t.Fatalf("NewStream failed: %v", err)
+	}
+	stream.WithTokenizer(sizeTokenizer{})
+
+	stream.AddSection("First")
+	stream.AddFile(sources.NewBufferInputFile("a.txt", []byte("content a")))
+	stream.AddPrompt("Analyze this")
+	stream.AddSection("Second")
+	stream.AddFile(sources.NewBufferInputFile("b.txt", []byte("content b")))
+
+	var buf strings.Builder
+	if err := stream.Execute(context.Background(), &buf); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	global := stream.GetGlobalContext()
+	if global.TokenEstimate != global.TotalWrittenBytes {
+		t.Errorf("TokenEstimate = %d, TotalWrittenBytes = %d; want equal with a one-token-per-byte tokenizer",
+			global.TokenEstimate, global.TotalWrittenBytes)
+	}
+	if global.TotalWrittenBytes != int64(buf.Len()) {
+		t.Errorf("TotalWrittenBytes = %d, want %d", global.TotalWrittenBytes, buf.Len())
+	}
+}
+
+func TestStream_PerFileTokenEstimateIsContentDerived(t *testing.T) {
+	cfg := core.NewConfig()
+	cfg.FileContentTemplate = "{{ .TokenEstimate }}"
+	stream, err := NewStream(cfg, core.RunnerConfig{Head: -1})
+	if err != nil {
+		t.Fatalf("NewStream failed: %v", err)
+	}
+
+	content := strings.Repeat(`{"a":1},`, 60)
+	stream.AddFile(sources.NewBufferInputFile("dense.json", []byte(content)))
+
+	var buf strings.Builder
+	if err := stream.Execute(context.Background(), &buf); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	got, err := strconv.ParseInt(strings.TrimSpace(buf.String()), 10, 64)
+	if err != nil {
+		t.Fatalf("parse rendered estimate %q: %v", buf.String(), err)
+	}
+
+	sizeOnly := int64(len(content)) / 4
+	if got == sizeOnly {
+		t.Errorf("per-file TokenEstimate = %d, which is exactly bytes/4; want a content-derived estimate", got)
+	}
+	if got <= sizeOnly {
+		t.Errorf("per-file TokenEstimate = %d, want greater than bytes/4 (%d) for symbol-dense content", got, sizeOnly)
 	}
 }


### PR DESCRIPTION
`DefaultTokenCounter` was unreachable from the CLI: `processor.go` set it, then `pipeline.go` overwrote it with the `size / 4` fallback, so every reported token count was just bytes/4.

Wires the real counter in and estimates over the bytes actually emitted. Code bundles were previously underestimated by ~30%, which matters for the 128k/200k color thresholds.