### PR TITLE
feat: add meta template context and stats counters

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -61,11 +61,13 @@ All keys are optional. Templates not listed here aren't recognized.
 | `section_template`        | template | format default | Renders a logical section break (from `-s`).                                                      |
 | `prompt_template`         | template | format default | Renders text injected via `-p` or `-P`.                                                           |
 | `tree_template`           | template | format default | Renders the tree block from `-t`/`-T`.                                                            |
+| `meta_template`           | template | format default | Renders the metadata block from `--system-context`.                                               |
 | `section_header_template` | template | format default | Wraps the start of every section (XML uses this for `<content>`/`<section>`).                     |
 | `section_footer_template` | template | format default | Wraps the end of every section.                                                                   |
 | `output_header_template`  | template | format default | Rendered once before the first section.                                                           |
 | `output_footer_template`  | template | format default | Rendered once after the last section.                                                             |
 | `stats_template`          | template | format default | Renders the file/token summary footer.                                                            |
+| `report_template`         | template | built-in       | Renders the detailed report from `--report`. One default across all formats.                       |
 
 ### Precedence for the prompts library
 
@@ -94,7 +96,8 @@ FileContext is bound to the five file templates (`file_content_template`, `file_
 |--------------------|----------------|----------------------------------------------------|
 | `Path`             | string         | Display path (relative when possible).             |
 | `AbsPath`          | string         | Absolute path on disk.                             |
-| `Size`             | int64          | Bytes. Pair with `humanize`.                       |
+| `Size`             | int64          | Bytes as rendered. Pair with `humanize`.           |
+| `OriginalSize`     | int64          | Bytes on disk, before any conversion.              |
 | `ModTime`          | time.Time      | Pair with `date "2006-01-02"`.                     |
 | `TotalRows`        | int            | Lines after slicing.                               |
 | `IsEstimate`       | bool           | True if rows are an estimate (e.g. binary skip).   |
@@ -106,7 +109,8 @@ FileContext is bound to the five file templates (`file_content_template`, `file_
 | `IsError`          | bool           |                                                    |
 | `ReadError`        | string         | Set when `IsError`.                                |
 | `TokenEstimate`    | int64          |                                                    |
-| `SkeletonMode`     | string         | `functions`, `types`, or empty.                    |
+| `SkeletonMode`     | string         | `function signatures`, `type definitions`, `definitions`, or empty. |
+| `ConvertedFrom`    | string         | Source format when content was converted, else empty. |
 | `FileIndex`        | int            | 1-based index across the whole run.                |
 | `SectionFileIndex` | int            | 1-based index within the current section.          |
 | `Section`          | SectionContext | Outer section info (notably `Section.TotalFiles`). |
@@ -134,13 +138,36 @@ PromptContext is bound to `prompt_template`:
 TreeContext is bound to `tree_template` and has the same shape as PromptContext, except Body holds the rendered tree
 text rather than an injected prompt string.
 
+MetaContext is bound to `meta_template`. Body is the pre-rendered block, and Fields carries the same values
+individually so a custom template can select and label them:
+
+| Field     | Type              | Notes                                                        |
+|-----------|-------------------|--------------------------------------------------------------|
+| `Body`    | string            | The default rendered block.                                  |
+| `Fields`  | map[string]string | Keys: `os`, `arch`, `time`, `host`, `version`, `command`.     |
+| `Section` | SectionContext    |                                                              |
+| `Global`  | GlobalContext     |                                                              |
+
 HeaderContext and FooterContext are bound to `output_header_template` and `output_footer_template`, and carry a single
 field, Global (a GlobalContext).
 
-StatsContext is bound to `stats_template` and carries Global only.
+StatsContext is bound to `stats_template` and carries Global plus ColorEnabled (a bool, false when output is piped or
+`NO_COLOR` is set).
+
+ReportContext is bound to `report_template`:
+
+| Field          | Type         | Notes                                                    |
+|----------------|--------------|----------------------------------------------------------|
+| `Files`        | []FileReport | One entry per rendered file, in output order.            |
+| `Top`          | []FileReport | Same entries ordered by descending token count.          |
+| `ColorEnabled` | bool         | As for StatsContext.                                     |
+| `Global`       | GlobalContext |                                                         |
+
+Each FileReport carries Path, OriginalSize, RenderedSize, Tokens, Rows, Language, and IsBinary.
 
 GlobalContext is reachable from every other context as `.Global`. Its fields are TotalFiles, TotalSize,
-TotalWrittenBytes, TokenEstimate, TotalSections, WorkDir, and Metadata (a map of string to string).
+TotalWrittenBytes, TotalRows, TokenEstimate, TotalSections, WorkDir, Metadata (a map of string to string), and the
+report breakdown counters SkippedBySize, BinaryFiles, and FailedFiles.
 
 ### Helper functions
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -67,7 +67,6 @@ All keys are optional. Templates not listed here aren't recognized.
 | `output_header_template`  | template | format default | Rendered once before the first section.                                                           |
 | `output_footer_template`  | template | format default | Rendered once after the last section.                                                             |
 | `stats_template`          | template | format default | Renders the file/token summary footer.                                                            |
-| `report_template`         | template | built-in       | Renders the detailed report from `--report`. One default across all formats.                       |
 
 ### Precedence for the prompts library
 
@@ -152,22 +151,12 @@ HeaderContext and FooterContext are bound to `output_header_template` and `outpu
 field, Global (a GlobalContext).
 
 StatsContext is bound to `stats_template` and carries Global plus ColorEnabled (a bool, false when output is piped or
-`NO_COLOR` is set).
-
-ReportContext is bound to `report_template`:
-
-| Field          | Type         | Notes                                                    |
-|----------------|--------------|----------------------------------------------------------|
-| `Files`        | []FileReport | One entry per rendered file, in output order.            |
-| `Top`          | []FileReport | Same entries ordered by descending token count.          |
-| `ColorEnabled` | bool         | As for StatsContext.                                     |
-| `Global`       | GlobalContext |                                                         |
-
-Each FileReport carries Path, OriginalSize, RenderedSize, Tokens, Rows, Language, and IsBinary.
+`NO_COLOR` is set). The default template adds a third line listing SkippedBySize, BinaryFiles, and FailedFiles, showing
+only the counters that are non-zero.
 
 GlobalContext is reachable from every other context as `.Global`. Its fields are TotalFiles, TotalSize,
 TotalWrittenBytes, TotalRows, TokenEstimate, TotalSections, WorkDir, Metadata (a map of string to string), and the
-report breakdown counters SkippedBySize, BinaryFiles, and FailedFiles.
+counters SkippedBySize, BinaryFiles, and FailedFiles.
 
 ### Helper functions
 

--- a/cmd/lx/golden_core_test.go
+++ b/cmd/lx/golden_core_test.go
@@ -118,6 +118,9 @@ func TestGoldenStats(t *testing.T) {
 		{name: "073_verbose_flag", args: []string{"--verbose=debug", "main.go"}},
 		{name: "074_no_stats", args: []string{"--no-stats", "main.go"}},
 		{name: "075_stats_auto_piped", args: []string{"main.go"}, autoStat: true},
+		{name: "076_stats_counters_binary", args: []string{"--stats", "main.go", "data.bin"}},
+		{name: "077_stats_counters_size_skip", args: []string{"--stats", "-m", "1k", "."}},
+		{name: "078_stats_no_counters_when_clean", args: []string{"--stats", "main.go"}},
 	})
 }
 

--- a/cmd/lx/goldenfixtures/core.go
+++ b/cmd/lx/goldenfixtures/core.go
@@ -126,6 +126,8 @@ func SetupStatsFixture(t *testing.T) string {
 	dir := t.TempDir()
 
 	writeFile(t, dir, "main.go", "package main\nfunc main() {}", 0644)
+	writeFile(t, dir, "data.bin", string([]byte{0x00, 0x01, 0xFF, 0xFE}), 0644)
+	buildLargeFile(t, dir, "large.txt")
 
 	return dir
 }

--- a/cmd/lx/testdata/golden/076_stats_counters_binary.golden
+++ b/cmd/lx/testdata/golden/076_stats_counters_binary.golden
@@ -1,0 +1,15 @@
+--- STDOUT ---
+[1/2] main.go (2 rows)
+---
+```go
+package main
+func main() {}
+```
+
+[2/2] data.bin - binary file skipped (4 B)
+
+
+--- STDERR ---
+  1 binary
+  ~46 tokens
+▎ 2 files · 3 rows · 1 section · 31 B

--- a/cmd/lx/testdata/golden/077_stats_counters_size_skip.golden
+++ b/cmd/lx/testdata/golden/077_stats_counters_size_skip.golden
@@ -1,0 +1,15 @@
+--- STDOUT ---
+[1/2] data.bin - binary file skipped (4 B)
+
+[2/2] main.go (2 rows)
+---
+```go
+package main
+func main() {}
+```
+
+
+--- STDERR ---
+  1 skipped (size) · 1 binary
+  ~46 tokens
+▎ 2 files · 3 rows · 1 section · 31 B

--- a/cmd/lx/testdata/golden/078_stats_no_counters_when_clean.golden
+++ b/cmd/lx/testdata/golden/078_stats_no_counters_when_clean.golden
@@ -1,0 +1,12 @@
+--- STDOUT ---
+main.go (2 rows)
+---
+```go
+package main
+func main() {}
+```
+
+
+--- STDERR ---
+  ~26 tokens
+▎ 1 file · 2 rows · 1 section · 27 B

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -20,6 +20,7 @@ type CliConfig struct {
 	SectionTemplate string `yaml:"section_template"`
 	PromptTemplate  string `yaml:"prompt_template"`
 	TreeTemplate    string `yaml:"tree_template"`
+	MetaTemplate    string `yaml:"meta_template"`
 
 	SectionHeaderTemplate string `yaml:"section_header_template"`
 	SectionFooterTemplate string `yaml:"section_footer_template"`
@@ -27,6 +28,7 @@ type CliConfig struct {
 	OutputHeaderTemplate string `yaml:"output_header_template"`
 	OutputFooterTemplate string `yaml:"output_footer_template"`
 	StatsTemplate        string `yaml:"stats_template"`
+	ReportTemplate       string `yaml:"report_template"`
 
 	OutputFormat string `yaml:"output_format"`
 
@@ -82,6 +84,7 @@ func LoadConfigChain(cliPath string) (*lx.Config, *CliConfig, error) {
 		overrideIfSet(&lxCfg.SectionTemplate, loaded.SectionTemplate)
 		overrideIfSet(&lxCfg.PromptTemplate, loaded.PromptTemplate)
 		overrideIfSet(&lxCfg.TreeTemplate, loaded.TreeTemplate)
+		overrideIfSet(&lxCfg.MetaTemplate, loaded.MetaTemplate)
 
 		overrideIfSet(&lxCfg.SectionHeaderTemplate, loaded.SectionHeaderTemplate)
 		overrideIfSet(&lxCfg.SectionFooterTemplate, loaded.SectionFooterTemplate)
@@ -89,6 +92,7 @@ func LoadConfigChain(cliPath string) (*lx.Config, *CliConfig, error) {
 		overrideIfSet(&lxCfg.OutputHeaderTemplate, loaded.OutputHeaderTemplate)
 		overrideIfSet(&lxCfg.OutputFooterTemplate, loaded.OutputFooterTemplate)
 		overrideIfSet(&lxCfg.StatsTemplate, loaded.StatsTemplate)
+		overrideIfSet(&lxCfg.ReportTemplate, loaded.ReportTemplate)
 
 		overrideIfSet(&lxCfg.OutputFormat, loaded.OutputFormat)
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -28,7 +28,6 @@ type CliConfig struct {
 	OutputHeaderTemplate string `yaml:"output_header_template"`
 	OutputFooterTemplate string `yaml:"output_footer_template"`
 	StatsTemplate        string `yaml:"stats_template"`
-	ReportTemplate       string `yaml:"report_template"`
 
 	OutputFormat string `yaml:"output_format"`
 
@@ -92,7 +91,6 @@ func LoadConfigChain(cliPath string) (*lx.Config, *CliConfig, error) {
 		overrideIfSet(&lxCfg.OutputHeaderTemplate, loaded.OutputHeaderTemplate)
 		overrideIfSet(&lxCfg.OutputFooterTemplate, loaded.OutputFooterTemplate)
 		overrideIfSet(&lxCfg.StatsTemplate, loaded.StatsTemplate)
-		overrideIfSet(&lxCfg.ReportTemplate, loaded.ReportTemplate)
 
 		overrideIfSet(&lxCfg.OutputFormat, loaded.OutputFormat)
 

--- a/pkg/lx/core/config.go
+++ b/pkg/lx/core/config.go
@@ -54,9 +54,6 @@ func Merge(dst *Config, src *Config) {
 	if src.StatsTemplate != "" {
 		dst.StatsTemplate = src.StatsTemplate
 	}
-	if src.ReportTemplate != "" {
-		dst.ReportTemplate = src.ReportTemplate
-	}
 
 	if src.OutputFormat != "" {
 		dst.OutputFormat = src.OutputFormat

--- a/pkg/lx/core/config.go
+++ b/pkg/lx/core/config.go
@@ -34,6 +34,9 @@ func Merge(dst *Config, src *Config) {
 	if src.TreeTemplate != "" {
 		dst.TreeTemplate = src.TreeTemplate
 	}
+	if src.MetaTemplate != "" {
+		dst.MetaTemplate = src.MetaTemplate
+	}
 
 	if src.SectionHeaderTemplate != "" {
 		dst.SectionHeaderTemplate = src.SectionHeaderTemplate
@@ -50,6 +53,9 @@ func Merge(dst *Config, src *Config) {
 	}
 	if src.StatsTemplate != "" {
 		dst.StatsTemplate = src.StatsTemplate
+	}
+	if src.ReportTemplate != "" {
+		dst.ReportTemplate = src.ReportTemplate
 	}
 
 	if src.OutputFormat != "" {

--- a/pkg/lx/core/types.go
+++ b/pkg/lx/core/types.go
@@ -55,7 +55,6 @@ type TemplateEngine struct {
 	OutputHeader *template.Template
 	OutputFooter *template.Template
 	Stats        *template.Template
-	Report       *template.Template
 }
 
 // Config represents the core library configuration.
@@ -77,17 +76,14 @@ type Config struct {
 	OutputHeaderTemplate string
 	OutputFooterTemplate string
 	StatsTemplate        string
-	ReportTemplate       string
 
 	OutputFormat string
 }
 
 // FileContext represents the data provided to file-level templates.
 type FileContext struct {
-	Path    string
-	AbsPath string
-	// Size is the size of the content as rendered. When a converter or
-	// skeleton filter ran, OriginalSize holds the file's size on disk.
+	Path             string
+	AbsPath          string
 	Size             int64
 	OriginalSize     int64
 	ModTime          time.Time
@@ -106,9 +102,7 @@ type FileContext struct {
 	Global           GlobalContext
 	Section          SectionContext
 	SkeletonMode     string
-	// ConvertedFrom names the source format when a converter replaced the
-	// content, so Language can describe what is actually rendered.
-	ConvertedFrom string
+	ConvertedFrom    string
 }
 
 // SectionContext represents the data provided to section templates.
@@ -136,8 +130,6 @@ type TreeContext struct {
 }
 
 // MetaContext represents the data provided to metadata block templates.
-// Body is the pre-rendered block; Fields exposes the same values individually
-// so custom templates can select and label them.
 type MetaContext struct {
 	Body    string
 	Fields  map[string]string
@@ -157,27 +149,6 @@ type FooterContext struct {
 
 // StatsContext represents the data provided to the statistics summary template.
 type StatsContext struct {
-	Global       GlobalContext
-	ColorEnabled bool
-}
-
-// FileReport is one file's row in the detailed report.
-type FileReport struct {
-	Path         string
-	OriginalSize int64
-	RenderedSize int64
-	Tokens       int64
-	Rows         int
-	Language     string
-	IsBinary     bool
-}
-
-// ReportContext represents the data provided to the detailed report template.
-// Files is in output order; Top is the same set ordered by descending token
-// count, so templates do not have to sort.
-type ReportContext struct {
-	Files        []FileReport
-	Top          []FileReport
 	Global       GlobalContext
 	ColorEnabled bool
 }

--- a/pkg/lx/core/types.go
+++ b/pkg/lx/core/types.go
@@ -15,6 +15,10 @@ type GlobalContext struct {
 	TotalSections     int
 	WorkDir           string
 	Metadata          map[string]string
+
+	SkippedBySize int
+	BinaryFiles   int
+	FailedFiles   int
 }
 
 // RunnerConfig defines slicing and formatting state for the rendering processor.
@@ -43,6 +47,7 @@ type TemplateEngine struct {
 	Section *template.Template
 	Prompt  *template.Template
 	Tree    *template.Template
+	Meta    *template.Template
 
 	SectionHeader *template.Template
 	SectionFooter *template.Template
@@ -50,6 +55,7 @@ type TemplateEngine struct {
 	OutputHeader *template.Template
 	OutputFooter *template.Template
 	Stats        *template.Template
+	Report       *template.Template
 }
 
 // Config represents the core library configuration.
@@ -63,6 +69,7 @@ type Config struct {
 	SectionTemplate string
 	PromptTemplate  string
 	TreeTemplate    string
+	MetaTemplate    string
 
 	SectionHeaderTemplate string
 	SectionFooterTemplate string
@@ -70,15 +77,19 @@ type Config struct {
 	OutputHeaderTemplate string
 	OutputFooterTemplate string
 	StatsTemplate        string
+	ReportTemplate       string
 
 	OutputFormat string
 }
 
 // FileContext represents the data provided to file-level templates.
 type FileContext struct {
-	Path             string
-	AbsPath          string
+	Path    string
+	AbsPath string
+	// Size is the size of the content as rendered. When a converter or
+	// skeleton filter ran, OriginalSize holds the file's size on disk.
 	Size             int64
+	OriginalSize     int64
 	ModTime          time.Time
 	TotalRows        int
 	ReadError        string
@@ -95,6 +106,9 @@ type FileContext struct {
 	Global           GlobalContext
 	Section          SectionContext
 	SkeletonMode     string
+	// ConvertedFrom names the source format when a converter replaced the
+	// content, so Language can describe what is actually rendered.
+	ConvertedFrom string
 }
 
 // SectionContext represents the data provided to section templates.
@@ -121,6 +135,16 @@ type TreeContext struct {
 	Section SectionContext
 }
 
+// MetaContext represents the data provided to metadata block templates.
+// Body is the pre-rendered block; Fields exposes the same values individually
+// so custom templates can select and label them.
+type MetaContext struct {
+	Body    string
+	Fields  map[string]string
+	Global  GlobalContext
+	Section SectionContext
+}
+
 // HeaderContext represents the data provided to the overall output header.
 type HeaderContext struct {
 	Global GlobalContext
@@ -133,6 +157,27 @@ type FooterContext struct {
 
 // StatsContext represents the data provided to the statistics summary template.
 type StatsContext struct {
+	Global       GlobalContext
+	ColorEnabled bool
+}
+
+// FileReport is one file's row in the detailed report.
+type FileReport struct {
+	Path         string
+	OriginalSize int64
+	RenderedSize int64
+	Tokens       int64
+	Rows         int
+	Language     string
+	IsBinary     bool
+}
+
+// ReportContext represents the data provided to the detailed report template.
+// Files is in output order; Top is the same set ordered by descending token
+// count, so templates do not have to sort.
+type ReportContext struct {
+	Files        []FileReport
+	Top          []FileReport
 	Global       GlobalContext
 	ColorEnabled bool
 }

--- a/pkg/lx/facade.go
+++ b/pkg/lx/facade.go
@@ -21,9 +21,12 @@ type FileContext = core.FileContext
 type SectionContext = core.SectionContext
 type PromptContext = core.PromptContext
 type TreeContext = core.TreeContext
+type MetaContext = core.MetaContext
 type HeaderContext = core.HeaderContext
 type FooterContext = core.FooterContext
 type StatsContext = core.StatsContext
+type ReportContext = core.ReportContext
+type FileReport = core.FileReport
 type TokenCounter = core.TokenCounter
 type Tokenizer = core.Tokenizer
 

--- a/pkg/lx/facade.go
+++ b/pkg/lx/facade.go
@@ -25,8 +25,6 @@ type MetaContext = core.MetaContext
 type HeaderContext = core.HeaderContext
 type FooterContext = core.FooterContext
 type StatsContext = core.StatsContext
-type ReportContext = core.ReportContext
-type FileReport = core.FileReport
 type TokenCounter = core.TokenCounter
 type Tokenizer = core.Tokenizer
 

--- a/pkg/lx/render/layout.go
+++ b/pkg/lx/render/layout.go
@@ -15,6 +15,8 @@ type Result struct {
 	Stats        int64
 	Rows         int
 	IsCompact    bool
+	IsBinary     bool
+	IsError      bool
 	Err          error
 	SectionIndex int
 }

--- a/pkg/lx/render/processor.go
+++ b/pkg/lx/render/processor.go
@@ -139,14 +139,15 @@ func (p *Processor) prepareFileContext(file sources.InputFile, index int, scratc
 			p.onFileError(file, err)
 		}
 		return core.FileContext{
-			Path:      file.Path,
-			AbsPath:   file.AbsPath,
-			Size:      file.Size,
-			ModTime:   file.ModTime,
-			FileIndex: index,
-			Global:    p.global,
-			ReadError: err.Error(),
-			IsError:   true,
+			Path:         file.Path,
+			AbsPath:      file.AbsPath,
+			Size:         file.Size,
+			OriginalSize: file.Size,
+			ModTime:      file.ModTime,
+			FileIndex:    index,
+			Global:       p.global,
+			ReadError:    err.Error(),
+			IsError:      true,
 		}, nil
 	}
 	defer rc.Close()
@@ -154,14 +155,15 @@ func (p *Processor) prepareFileContext(file sources.InputFile, index int, scratc
 	if f, ok := rc.(*os.File); ok {
 		if stat, err := f.Stat(); err == nil && stat.IsDir() {
 			return core.FileContext{
-				Path:      file.Path,
-				AbsPath:   file.AbsPath,
-				Size:      file.Size,
-				ModTime:   file.ModTime,
-				FileIndex: index,
-				Global:    p.global,
-				ReadError: "is a directory",
-				IsError:   true,
+				Path:         file.Path,
+				AbsPath:      file.AbsPath,
+				Size:         file.Size,
+				OriginalSize: file.Size,
+				ModTime:      file.ModTime,
+				FileIndex:    index,
+				Global:       p.global,
+				ReadError:    "is a directory",
+				IsError:      true,
 			}, nil
 		}
 	}
@@ -248,14 +250,15 @@ func (p *Processor) prepareFileContext(file sources.InputFile, index int, scratc
 		head, tail, gap, err := p.readSlices(reader, size, totalRows, !exact, effectiveCfg)
 		if err != nil {
 			return core.FileContext{
-				Path:      file.Path,
-				AbsPath:   file.AbsPath,
-				Size:      file.Size,
-				ModTime:   file.ModTime,
-				FileIndex: index,
-				Global:    p.global,
-				ReadError: err.Error(),
-				IsError:   true,
+				Path:         file.Path,
+				AbsPath:      file.AbsPath,
+				Size:         file.Size,
+				OriginalSize: file.Size,
+				ModTime:      file.ModTime,
+				FileIndex:    index,
+				Global:       p.global,
+				ReadError:    err.Error(),
+				IsError:      true,
 			}, nil
 		}
 		contentData = p.formatContent(head, tail, gap, totalRows, effectiveCfg)
@@ -265,6 +268,7 @@ func (p *Processor) prepareFileContext(file sources.InputFile, index int, scratc
 		Path:          file.Path,
 		AbsPath:       file.AbsPath,
 		Size:          size,
+		OriginalSize:  file.Size,
 		TotalRows:     displayRows,
 		IsEstimate:    !displayExact,
 		Language:      lang,

--- a/pkg/lx/render/processor.go
+++ b/pkg/lx/render/processor.go
@@ -32,6 +32,8 @@ type Processor struct {
 	tokenCounter   core.TokenCounter
 	onFileError    FileErrorHandler
 	lastWasCompact bool
+	lastWasBinary  bool
+	lastWasError   bool
 	lastRows       int
 	format         string
 }
@@ -65,6 +67,10 @@ func (p *Processor) LastWasCompact() bool { return p.lastWasCompact }
 
 func (p *Processor) LastRows() int { return p.lastRows }
 
+func (p *Processor) LastWasBinary() bool { return p.lastWasBinary }
+
+func (p *Processor) LastWasError() bool { return p.lastWasError }
+
 // RenderPrepared processes one item containing pre-calculated section and indices.
 func (p *Processor) RenderPrepared(w io.Writer, item PreparedItem, scratchBuf []byte) error {
 	var isCompact bool
@@ -73,6 +79,8 @@ func (p *Processor) RenderPrepared(w io.Writer, item PreparedItem, scratchBuf []
 	var templateToUse *template.Template
 
 	p.lastRows = 0
+	p.lastWasBinary = false
+	p.lastWasError = false
 	switch v := item.Raw.(type) {
 	case sources.InputFile:
 		var fCtx core.FileContext
@@ -85,6 +93,8 @@ func (p *Processor) RenderPrepared(w io.Writer, item PreparedItem, scratchBuf []
 
 		isCompact = fCtx.IsCompactView
 		p.lastRows = fCtx.TotalRows
+		p.lastWasBinary = fCtx.IsBinary
+		p.lastWasError = fCtx.IsError
 		ctx = &fCtx
 
 		if fCtx.IsError {

--- a/pkg/lx/streaming/pipeline.go
+++ b/pkg/lx/streaming/pipeline.go
@@ -22,7 +22,13 @@ var readPool = sync.Pool{New: func() interface{} {
 	return &b
 }}
 
-func (s *Stream) executePipeline(ctx context.Context, dest *byteCounter, global core.GlobalContext) (int64, error) {
+type pipelineTotals struct {
+	rows   int64
+	binary int
+	failed int
+}
+
+func (s *Stream) executePipeline(ctx context.Context, dest *byteCounter, global core.GlobalContext) (pipelineTotals, error) {
 	numWorkers := s.concurrency
 	jobsCh := make(chan seqJob, numWorkers)
 	resultsCh := make(chan render.Result, numWorkers)
@@ -62,6 +68,8 @@ func (s *Stream) executePipeline(ctx context.Context, dest *byteCounter, global 
 					Stats:        localCounter.count,
 					Rows:         proc.LastRows(),
 					IsCompact:    proc.LastWasCompact(),
+					IsBinary:     proc.LastWasBinary(),
+					IsError:      proc.LastWasError(),
 					Err:          err,
 					SectionIndex: j.item.Section.Index,
 				}:
@@ -92,13 +100,19 @@ func (s *Stream) executePipeline(ctx context.Context, dest *byteCounter, global 
 
 	nextSeq := 0
 	buffer := make(map[int]render.Result)
-	var totalRows int64
+	var totals pipelineTotals
 
 	for res := range resultsCh {
 		if res.Err != nil {
-			return totalRows, res.Err
+			return totals, res.Err
 		}
-		totalRows += int64(res.Rows)
+		totals.rows += int64(res.Rows)
+		if res.IsBinary {
+			totals.binary++
+		}
+		if res.IsError {
+			totals.failed++
+		}
 		buffer[res.Index] = res
 
 		for {
@@ -107,14 +121,14 @@ func (s *Stream) executePipeline(ctx context.Context, dest *byteCounter, global 
 				break
 			}
 			if err := layout.WriteItem(next); err != nil {
-				return totalRows, err
+				return totals, err
 			}
 			bufferPool.Put(next.Buffer)
 			delete(buffer, nextSeq)
 			nextSeq++
 		}
 	}
-	return totalRows, nil
+	return totals, nil
 }
 
 // byteCounter counts bytes written, plus token estimates when a tokenizer is

--- a/pkg/lx/streaming/stream.go
+++ b/pkg/lx/streaming/stream.go
@@ -192,7 +192,7 @@ func (s *Stream) Execute(ctx context.Context, w io.Writer) error {
 	if err := s.engine.OutputHeader.Execute(counter, core.HeaderContext{Global: global}); err != nil {
 		return err
 	}
-	totalRows, err := s.executePipeline(ctx, counter, global)
+	totals, err := s.executePipeline(ctx, counter, global)
 	if err != nil {
 		return err
 	}
@@ -201,7 +201,9 @@ func (s *Stream) Execute(ctx context.Context, w io.Writer) error {
 	}
 
 	global.TotalWrittenBytes = counter.count
-	global.TotalRows = totalRows
+	global.TotalRows = totals.rows
+	global.BinaryFiles = totals.binary
+	global.FailedFiles = totals.failed
 	global.TokenEstimate = counter.tokens
 	s.finalStats = &global
 	return nil

--- a/pkg/lx/streaming/stream.go
+++ b/pkg/lx/streaming/stream.go
@@ -34,6 +34,8 @@ type Stream struct {
 	onFileError FileErrorHandler
 	concurrency int
 	prepared    []render.PreparedItem
+
+	skippedBySize int
 }
 
 func NewStream(cfg *core.Config, runnerCfg core.RunnerConfig) (*Stream, error) {
@@ -87,6 +89,7 @@ func (s *Stream) AddFile(f sources.InputFile) *Stream {
 	f.Config = s.renderCfg
 	if s.renderCfg.MaxSize > 0 && f.Size > s.renderCfg.MaxSize {
 		slog.Debug("Skipped by size limit (-m)", "path", f.Path, "size", f.Size, "max_size", s.renderCfg.MaxSize)
+		s.skippedBySize++
 		return s
 	}
 	s.items = append(s.items, f)
@@ -115,8 +118,9 @@ func (s *Stream) Prepare() core.GlobalContext {
 	}
 
 	global := core.GlobalContext{
-		WorkDir:  s.workDir,
-		Metadata: make(map[string]string),
+		WorkDir:       s.workDir,
+		Metadata:      make(map[string]string),
+		SkippedBySize: s.skippedBySize,
 	}
 
 	s.sections = make([]*core.SectionContext, 0)

--- a/pkg/lx/streaming/stream_test.go
+++ b/pkg/lx/streaming/stream_test.go
@@ -2,6 +2,7 @@ package streaming
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -254,5 +255,53 @@ func TestStream_PerFileTokenEstimateIsContentDerived(t *testing.T) {
 	}
 	if got <= sizeOnly {
 		t.Errorf("per-file TokenEstimate = %d, want greater than bytes/4 (%d) for symbol-dense content", got, sizeOnly)
+	}
+}
+
+func TestStream_SkippedBySizeIsCounted(t *testing.T) {
+	stream, err := NewStream(core.NewConfig(), core.RunnerConfig{Head: -1, MaxSize: 10})
+	if err != nil {
+		t.Fatalf("NewStream failed: %v", err)
+	}
+
+	stream.AddFile(sources.NewBufferInputFile("small.txt", []byte("tiny")))
+	stream.AddFile(sources.NewBufferInputFile("big1.txt", []byte(strings.Repeat("x", 64))))
+	stream.AddFile(sources.NewBufferInputFile("big2.txt", []byte(strings.Repeat("y", 99))))
+
+	g := stream.GetGlobalContext()
+	if g.SkippedBySize != 2 {
+		t.Errorf("SkippedBySize = %d, want 2", g.SkippedBySize)
+	}
+	if g.TotalFiles != 1 {
+		t.Errorf("TotalFiles = %d, want 1", g.TotalFiles)
+	}
+}
+
+func TestStream_OriginalSizeIsPreConversionSize(t *testing.T) {
+	cfg := core.NewConfig()
+	cfg.FileContentTemplate = "{{ .OriginalSize }} {{ .Size }}"
+	stream, err := NewStream(cfg, core.RunnerConfig{Head: -1, SkeletonFunctions: true})
+	if err != nil {
+		t.Fatalf("NewStream failed: %v", err)
+	}
+
+	src := "package main\n\nfunc Alpha() int {\n\treturn 1\n}\n\nfunc Beta() int {\n\treturn 2\n}\n"
+	stream.AddFile(sources.NewBufferInputFile("main.go", []byte(src)))
+
+	var buf strings.Builder
+	if err := stream.Execute(context.Background(), &buf); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	var original, rendered int64
+	if _, err := fmt.Sscanf(strings.TrimSpace(buf.String()), "%d %d", &original, &rendered); err != nil {
+		t.Fatalf("parse %q: %v", buf.String(), err)
+	}
+
+	if original != int64(len(src)) {
+		t.Errorf("OriginalSize = %d, want %d (size on disk)", original, len(src))
+	}
+	if rendered >= original {
+		t.Errorf("Size = %d, want less than OriginalSize %d after the skeleton filter", rendered, original)
 	}
 }

--- a/pkg/lx/templatex/compile.go
+++ b/pkg/lx/templatex/compile.go
@@ -72,6 +72,11 @@ func Compile(cfg *core.Config) (*core.TemplateEngine, error) {
 		return nil, fmt.Errorf("tree template: %w", err)
 	}
 
+	tMeta, err := parse("meta", pick(cfg.MetaTemplate, defaults.Meta))
+	if err != nil {
+		return nil, fmt.Errorf("meta template: %w", err)
+	}
+
 	tSecHeader, err := parse("section_header", pick(cfg.SectionHeaderTemplate, defaults.SectionHeader))
 	if err != nil {
 		return nil, fmt.Errorf("section_header template: %w", err)
@@ -93,6 +98,10 @@ func Compile(cfg *core.Config) (*core.TemplateEngine, error) {
 	if err != nil {
 		return nil, fmt.Errorf("stats template: %w", err)
 	}
+	tReport, err := parse("report", pick(cfg.ReportTemplate, defaultReportTemplate))
+	if err != nil {
+		return nil, fmt.Errorf("report template: %w", err)
+	}
 
 	return &core.TemplateEngine{
 		FileContent:   tContent,
@@ -102,10 +111,12 @@ func Compile(cfg *core.Config) (*core.TemplateEngine, error) {
 		Section:       tSection,
 		Prompt:        tPrompt,
 		Tree:          tTree,
+		Meta:          tMeta,
 		SectionHeader: tSecHeader,
 		SectionFooter: tSecFooter,
 		OutputHeader:  tHeader,
 		OutputFooter:  tFooter,
 		Stats:         tStats,
+		Report:        tReport,
 	}, nil
 }

--- a/pkg/lx/templatex/compile.go
+++ b/pkg/lx/templatex/compile.go
@@ -98,10 +98,6 @@ func Compile(cfg *core.Config) (*core.TemplateEngine, error) {
 	if err != nil {
 		return nil, fmt.Errorf("stats template: %w", err)
 	}
-	tReport, err := parse("report", pick(cfg.ReportTemplate, defaultReportTemplate))
-	if err != nil {
-		return nil, fmt.Errorf("report template: %w", err)
-	}
 
 	return &core.TemplateEngine{
 		FileContent:   tContent,
@@ -117,6 +113,5 @@ func Compile(cfg *core.Config) (*core.TemplateEngine, error) {
 		OutputHeader:  tHeader,
 		OutputFooter:  tFooter,
 		Stats:         tStats,
-		Report:        tReport,
 	}, nil
 }

--- a/pkg/lx/templatex/contexts_test.go
+++ b/pkg/lx/templatex/contexts_test.go
@@ -1,0 +1,156 @@
+package templatex
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rasros/lx/pkg/lx/core"
+)
+
+func compileForFormat(t *testing.T, format string) *core.TemplateEngine {
+	t.Helper()
+	cfg := core.NewConfig()
+	cfg.OutputFormat = format
+	engine, err := Compile(cfg)
+	if err != nil {
+		t.Fatalf("Compile(%s) failed: %v", format, err)
+	}
+	return engine
+}
+
+func TestCompileProvidesMetaAndReportForEveryFormat(t *testing.T) {
+	for _, format := range []string{"markdown", "xml", "html", "bare"} {
+		engine := compileForFormat(t, format)
+		if engine.Meta == nil {
+			t.Errorf("format %s: Meta template is nil", format)
+		}
+		if engine.Report == nil {
+			t.Errorf("format %s: Report template is nil", format)
+		}
+	}
+}
+
+func TestMetaTemplateRendersBody(t *testing.T) {
+	cases := map[string]string{
+		"markdown": "OS: linux",
+		"xml":      "<system_context>",
+		"html":     "<pre class=\"system-context\">",
+	}
+
+	for format, want := range cases {
+		engine := compileForFormat(t, format)
+		var sb strings.Builder
+		err := engine.Meta.Execute(&sb, core.MetaContext{
+			Body:   "OS: linux",
+			Fields: map[string]string{"os": "linux"},
+		})
+		if err != nil {
+			t.Errorf("format %s: Execute failed: %v", format, err)
+			continue
+		}
+		if !strings.Contains(sb.String(), want) {
+			t.Errorf("format %s: output %q missing %q", format, sb.String(), want)
+		}
+	}
+}
+
+func TestMetaTemplateExposesFields(t *testing.T) {
+	cfg := core.NewConfig()
+	cfg.MetaTemplate = "{{ .Fields.os }}/{{ .Fields.arch }}"
+	engine, err := Compile(cfg)
+	if err != nil {
+		t.Fatalf("Compile failed: %v", err)
+	}
+
+	var sb strings.Builder
+	err = engine.Meta.Execute(&sb, core.MetaContext{
+		Fields: map[string]string{"os": "linux", "arch": "amd64"},
+	})
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if got := sb.String(); got != "linux/amd64" {
+		t.Errorf("got %q, want %q", got, "linux/amd64")
+	}
+}
+
+func TestReportTemplateRendersRowsAndBreakdown(t *testing.T) {
+	engine := compileForFormat(t, "markdown")
+
+	ctx := core.ReportContext{
+		Files: []core.FileReport{
+			{Path: "docs/manual.pdf", OriginalSize: 12_400_000, RenderedSize: 180_000, Tokens: 45_000},
+			{Path: "src/main.go", OriginalSize: 45_000, RenderedSize: 45_000, Tokens: 11_200},
+		},
+		Top: []core.FileReport{{Path: "docs/manual.pdf"}, {Path: "src/main.go"}},
+		Global: core.GlobalContext{
+			TotalFiles:    2,
+			SkippedBySize: 3,
+			BinaryFiles:   1,
+			FailedFiles:   0,
+			TokenEstimate: 56_200,
+		},
+	}
+
+	var sb strings.Builder
+	if err := engine.Report.Execute(&sb, ctx); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	got := sb.String()
+	for _, want := range []string{
+		"docs/manual.pdf",
+		"12.4 MB",
+		"180.0 kB",
+		"45,000",
+		"src/main.go",
+		"Largest: docs/manual.pdf, src/main.go",
+		"2 processed",
+		"3 skipped (size)",
+		"1 binary",
+		"0 failed",
+		"~56,200 tokens",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("report output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// An empty report must not emit a headerless table.
+func TestReportTemplateOmitsTableWhenNoFiles(t *testing.T) {
+	engine := compileForFormat(t, "markdown")
+
+	var sb strings.Builder
+	if err := engine.Report.Execute(&sb, core.ReportContext{}); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	got := sb.String()
+	if strings.Contains(got, "| File |") {
+		t.Errorf("empty report rendered a table header:\n%s", got)
+	}
+	if !strings.Contains(got, "0 processed") {
+		t.Errorf("empty report missing breakdown:\n%s", got)
+	}
+}
+
+func TestCustomReportTemplateOverridesDefault(t *testing.T) {
+	cfg := core.NewConfig()
+	cfg.ReportTemplate = "{{ len .Files }} files"
+	engine, err := Compile(cfg)
+	if err != nil {
+		t.Fatalf("Compile failed: %v", err)
+	}
+
+	var sb strings.Builder
+	err = engine.Report.Execute(&sb, core.ReportContext{
+		Files: []core.FileReport{{Path: "a.go"}, {Path: "b.go"}},
+	})
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if got := sb.String(); got != "2 files" {
+		t.Errorf("got %q, want %q", got, "2 files")
+	}
+}

--- a/pkg/lx/templatex/contexts_test.go
+++ b/pkg/lx/templatex/contexts_test.go
@@ -18,14 +18,10 @@ func compileForFormat(t *testing.T, format string) *core.TemplateEngine {
 	return engine
 }
 
-func TestCompileProvidesMetaAndReportForEveryFormat(t *testing.T) {
+func TestCompileProvidesMetaForEveryFormat(t *testing.T) {
 	for _, format := range []string{"markdown", "xml", "html", "bare"} {
-		engine := compileForFormat(t, format)
-		if engine.Meta == nil {
+		if engine := compileForFormat(t, format); engine.Meta == nil {
 			t.Errorf("format %s: Meta template is nil", format)
-		}
-		if engine.Report == nil {
-			t.Errorf("format %s: Report template is nil", format)
 		}
 	}
 }
@@ -74,83 +70,48 @@ func TestMetaTemplateExposesFields(t *testing.T) {
 	}
 }
 
-func TestReportTemplateRendersRowsAndBreakdown(t *testing.T) {
+func renderStats(t *testing.T, g core.GlobalContext) string {
+	t.Helper()
 	engine := compileForFormat(t, "markdown")
-
-	ctx := core.ReportContext{
-		Files: []core.FileReport{
-			{Path: "docs/manual.pdf", OriginalSize: 12_400_000, RenderedSize: 180_000, Tokens: 45_000},
-			{Path: "src/main.go", OriginalSize: 45_000, RenderedSize: 45_000, Tokens: 11_200},
-		},
-		Top: []core.FileReport{{Path: "docs/manual.pdf"}, {Path: "src/main.go"}},
-		Global: core.GlobalContext{
-			TotalFiles:    2,
-			SkippedBySize: 3,
-			BinaryFiles:   1,
-			FailedFiles:   0,
-			TokenEstimate: 56_200,
-		},
-	}
-
 	var sb strings.Builder
-	if err := engine.Report.Execute(&sb, ctx); err != nil {
+	if err := engine.Stats.Execute(&sb, core.StatsContext{Global: g}); err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
+	return sb.String()
+}
 
-	got := sb.String()
-	for _, want := range []string{
-		"docs/manual.pdf",
-		"12.4 MB",
-		"180.0 kB",
-		"45,000",
-		"src/main.go",
-		"Largest: docs/manual.pdf, src/main.go",
-		"2 processed",
-		"3 skipped (size)",
-		"1 binary",
-		"0 failed",
-		"~56,200 tokens",
-	} {
-		if !strings.Contains(got, want) {
-			t.Errorf("report output missing %q:\n%s", want, got)
+func TestStatsOmitsCounterLineWhenNothingLeftOut(t *testing.T) {
+	got := renderStats(t, core.GlobalContext{TotalFiles: 3, TotalRows: 40, TotalSections: 1, TotalSize: 900})
+	for _, unwanted := range []string{"skipped", "binary", "failed"} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("stats mentions %q with all counters zero:\n%s", unwanted, got)
 		}
 	}
 }
 
-// An empty report must not emit a headerless table.
-func TestReportTemplateOmitsTableWhenNoFiles(t *testing.T) {
-	engine := compileForFormat(t, "markdown")
-
-	var sb strings.Builder
-	if err := engine.Report.Execute(&sb, core.ReportContext{}); err != nil {
-		t.Fatalf("Execute failed: %v", err)
+func TestStatsShowsOnlyNonZeroCounters(t *testing.T) {
+	got := renderStats(t, core.GlobalContext{TotalFiles: 3, SkippedBySize: 2})
+	if !strings.Contains(got, "2 skipped (size)") {
+		t.Errorf("stats missing skipped count:\n%s", got)
 	}
-
-	got := sb.String()
-	if strings.Contains(got, "| File |") {
-		t.Errorf("empty report rendered a table header:\n%s", got)
-	}
-	if !strings.Contains(got, "0 processed") {
-		t.Errorf("empty report missing breakdown:\n%s", got)
+	if strings.Contains(got, "binary") || strings.Contains(got, "failed") {
+		t.Errorf("stats shows zero-valued counters:\n%s", got)
 	}
 }
 
-func TestCustomReportTemplateOverridesDefault(t *testing.T) {
-	cfg := core.NewConfig()
-	cfg.ReportTemplate = "{{ len .Files }} files"
-	engine, err := Compile(cfg)
-	if err != nil {
-		t.Fatalf("Compile failed: %v", err)
-	}
-
-	var sb strings.Builder
-	err = engine.Report.Execute(&sb, core.ReportContext{
-		Files: []core.FileReport{{Path: "a.go"}, {Path: "b.go"}},
+func TestStatsSeparatesMultipleCounters(t *testing.T) {
+	got := renderStats(t, core.GlobalContext{
+		TotalFiles: 9, SkippedBySize: 2, BinaryFiles: 4, FailedFiles: 1,
 	})
-	if err != nil {
-		t.Fatalf("Execute failed: %v", err)
+	want := "2 skipped (size) · 4 binary · 1 failed"
+	if !strings.Contains(got, want) {
+		t.Errorf("stats counter line = %q, want it to contain %q", got, want)
 	}
-	if got := sb.String(); got != "2 files" {
-		t.Errorf("got %q, want %q", got, "2 files")
+}
+
+func TestStatsCounterLineHasNoLeadingSeparator(t *testing.T) {
+	got := renderStats(t, core.GlobalContext{TotalFiles: 5, BinaryFiles: 3})
+	if !strings.Contains(got, "  3 binary\n") {
+		t.Errorf("stats counter line malformed:\n%q", got)
 	}
 }

--- a/pkg/lx/templatex/defaults.go
+++ b/pkg/lx/templatex/defaults.go
@@ -22,6 +22,7 @@ type formatDefaults struct {
 	Section       string
 	Prompt        string
 	Tree          string
+	Meta          string
 	OutputHeader  string
 	OutputFooter  string
 	SectionHeader string
@@ -41,6 +42,7 @@ func getFormatDefaults(fmtType string) formatDefaults {
 			SectionFooter: defaultXMLSectionFooter,
 			Prompt:        defaultXMLPrompt,
 			Tree:          defaultXMLTree,
+			Meta:          defaultXMLMeta,
 			OutputFooter:  defaultXMLOutputFooter,
 		}
 	case "html":
@@ -54,6 +56,7 @@ func getFormatDefaults(fmtType string) formatDefaults {
 			SectionFooter: defaultHTMLSectionFooter,
 			Prompt:        defaultHTMLPrompt,
 			Tree:          defaultHTMLTree,
+			Meta:          defaultHTMLMeta,
 			OutputHeader:  defaultHTMLOutputHeader,
 			OutputFooter:  defaultHTMLOutputFooter,
 		}
@@ -67,6 +70,7 @@ func getFormatDefaults(fmtType string) formatDefaults {
 			Section:     defaultBareSection,
 			Prompt:      defaultBarePrompt,
 			Tree:        defaultBareTree,
+			Meta:        defaultBareMeta,
 		}
 	default: // markdown
 		return formatDefaults{
@@ -78,6 +82,7 @@ func getFormatDefaults(fmtType string) formatDefaults {
 			Section:      defaultMarkdownSection,
 			Prompt:       defaultPrompt,
 			Tree:         defaultMarkdownTree,
+			Meta:         defaultMarkdownMeta,
 			OutputFooter: defaultMarkdownOutputFooter,
 		}
 	}
@@ -95,6 +100,7 @@ const defaultMarkdownCompact = `{{ template "file_header" . }} ({{ if .IsEstimat
 const defaultMarkdownSection = `## {{ .Body | endNewline }}---`
 const defaultPrompt = `{{ .Body | endNewline }}`
 const defaultMarkdownTree = "```\n" + `{{ .Body | endNewline -}}` + "```"
+const defaultMarkdownMeta = "```\n" + `{{ .Body | endNewline -}}` + "```"
 const defaultMarkdownOutputFooter = "\n\n"
 
 const defaultXMLContent = `  <document index="{{ .FileIndex }}"{{ if .Language }} language="{{ .Language }}"{{ end }} rows="{{ .TotalRows }}"{{ if .SkeletonMode }} skeleton="{{ .SkeletonMode }}"{{ end }}>
@@ -125,6 +131,8 @@ const defaultXMLPrompt = `  <instruction>` + "\n" +
 	`  </instruction>`
 const defaultXMLTree = `  <tree>
 {{ .Body | endNewline }}  </tree>`
+const defaultXMLMeta = `  <system_context>
+{{ .Body | endNewline }}  </system_context>`
 const defaultXMLOutputFooter = "\n\n"
 
 const defaultHTMLOutputHeader = `<!DOCTYPE html>
@@ -231,6 +239,7 @@ const defaultHTMLSection = `<section id="section-{{ .Index }}"><h2><a href="#sec
 const defaultHTMLSectionFooter = `</section>`
 const defaultHTMLPrompt = `<blockquote>{{ .Body | endNewline }}</blockquote>`
 const defaultHTMLTree = `<pre class="file-tree">{{ .Body | escape | endNewline }}</pre>`
+const defaultHTMLMeta = `<pre class="system-context">{{ .Body | escape | endNewline }}</pre>`
 
 const defaultBareFileHeader = ``
 const defaultBareContent = `{{ .Content | endNewline -}}`
@@ -240,6 +249,7 @@ const defaultBareCompact = ``
 const defaultBareSection = ``
 const defaultBarePrompt = ``
 const defaultBareTree = ``
+const defaultBareMeta = ``
 
 const (
 	ansiReset  = "\x1b[0m"
@@ -262,6 +272,22 @@ const defaultStatsTemplate = `{{ accent .ColorEnabled "▎" }} ` +
 	`{{ commafy .Global.TotalRows }} {{ plural .Global.TotalRows "row" "rows" }} {{ dim .ColorEnabled "·" }} ` +
 	`{{ commafy .Global.TotalSections }} {{ plural .Global.TotalSections "section" "sections" }} {{ dim .ColorEnabled "·" }} ` +
 	`{{ humanize .Global.TotalSize }}` + "\n" +
+	`  {{ tokenLabel .Global.TokenEstimate .ColorEnabled }}` + "\n"
+
+// The report is a diagnostic summary rather than bundle content, so it has one
+// default across formats, like the stats summary.
+const defaultReportTemplate = `{{ if .Files }}` +
+	"| File | Original | Rendered | Tokens |\n" +
+	"|------|----------|----------|--------|\n" +
+	`{{ range .Files }}| {{ .Path }} | {{ humanize .OriginalSize }} | {{ humanize .RenderedSize }} | {{ commafy .Tokens }} |` + "\n" +
+	`{{ end }}` + "\n" +
+	`{{ end }}` +
+	`{{ if .Top }}Largest: {{ range $i, $f := .Top }}{{ if $i }}, {{ end }}{{ $f.Path }}{{ end }}` + "\n" +
+	`{{ end }}` +
+	`{{ commafy .Global.TotalFiles }} processed {{ dim .ColorEnabled "·" }} ` +
+	`{{ commafy .Global.SkippedBySize }} skipped (size) {{ dim .ColorEnabled "·" }} ` +
+	`{{ commafy .Global.BinaryFiles }} binary {{ dim .ColorEnabled "·" }} ` +
+	`{{ commafy .Global.FailedFiles }} failed` + "\n" +
 	`  {{ tokenLabel .Global.TokenEstimate .ColorEnabled }}` + "\n"
 
 func templateFuncs() template.FuncMap {

--- a/pkg/lx/templatex/defaults.go
+++ b/pkg/lx/templatex/defaults.go
@@ -272,23 +272,13 @@ const defaultStatsTemplate = `{{ accent .ColorEnabled "▎" }} ` +
 	`{{ commafy .Global.TotalRows }} {{ plural .Global.TotalRows "row" "rows" }} {{ dim .ColorEnabled "·" }} ` +
 	`{{ commafy .Global.TotalSections }} {{ plural .Global.TotalSections "section" "sections" }} {{ dim .ColorEnabled "·" }} ` +
 	`{{ humanize .Global.TotalSize }}` + "\n" +
-	`  {{ tokenLabel .Global.TokenEstimate .ColorEnabled }}` + "\n"
-
-// The report is a diagnostic summary rather than bundle content, so it has one
-// default across formats, like the stats summary.
-const defaultReportTemplate = `{{ if .Files }}` +
-	"| File | Original | Rendered | Tokens |\n" +
-	"|------|----------|----------|--------|\n" +
-	`{{ range .Files }}| {{ .Path }} | {{ humanize .OriginalSize }} | {{ humanize .RenderedSize }} | {{ commafy .Tokens }} |` + "\n" +
-	`{{ end }}` + "\n" +
-	`{{ end }}` +
-	`{{ if .Top }}Largest: {{ range $i, $f := .Top }}{{ if $i }}, {{ end }}{{ $f.Path }}{{ end }}` + "\n" +
-	`{{ end }}` +
-	`{{ commafy .Global.TotalFiles }} processed {{ dim .ColorEnabled "·" }} ` +
-	`{{ commafy .Global.SkippedBySize }} skipped (size) {{ dim .ColorEnabled "·" }} ` +
-	`{{ commafy .Global.BinaryFiles }} binary {{ dim .ColorEnabled "·" }} ` +
-	`{{ commafy .Global.FailedFiles }} failed` + "\n" +
-	`  {{ tokenLabel .Global.TokenEstimate .ColorEnabled }}` + "\n"
+	`  {{ tokenLabel .Global.TokenEstimate .ColorEnabled }}` + "\n" +
+	`{{ if or .Global.SkippedBySize .Global.BinaryFiles .Global.FailedFiles }}  ` +
+	`{{ $sep := "" }}` +
+	`{{ if .Global.SkippedBySize }}{{ commafy .Global.SkippedBySize }} skipped (size){{ $sep = printf " %s " (dim .ColorEnabled "·") }}{{ end }}` +
+	`{{ if .Global.BinaryFiles }}{{ $sep }}{{ commafy .Global.BinaryFiles }} binary{{ $sep = printf " %s " (dim .ColorEnabled "·") }}{{ end }}` +
+	`{{ if .Global.FailedFiles }}{{ $sep }}{{ commafy .Global.FailedFiles }} failed{{ end }}` +
+	"\n" + `{{ end }}`
 
 func templateFuncs() template.FuncMap {
 	return template.FuncMap{


### PR DESCRIPTION
Adds `MetaContext` + `meta_template` (per-format) for `--system-context`, and three counters on `GlobalContext` — `SkippedBySize`, `BinaryFiles`, `FailedFiles` — surfaced as a third stats line that only appears when non-zero.

Also adds `FileContext.OriginalSize` (pre-conversion size, previously dropped) and `ConvertedFrom` for the upcoming HTML/media converters.

No report template — that scope was dropped in favour of folding the counters into `--stats`.

Part of #81.