### PR TITLE
feat: add --system-context action

### DIFF
--- a/cmd/lx/golden_meta_test.go
+++ b/cmd/lx/golden_meta_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestGoldenSystemContext(t *testing.T) {
+	dir := setupSectionsFixture(t)
+	runTestGolden(t, dir, []goldenTestCase{
+		{name: "160_system_context_only", args: []string{"--system-context"}},
+		{name: "161_system_context_before_files", args: []string{"--system-context", "main.go"}},
+		{name: "162_system_context_after_files", args: []string{"main.go", "--system-context"}},
+		{name: "163_system_context_xml", args: []string{"--xml", "--system-context", "main.go"}},
+		{name: "164_system_context_bare", args: []string{"--bare", "--system-context", "main.go"}},
+		{name: "165_system_context_html", args: []string{"--html", "--system-context", "main.go"}},
+		{name: "166_system_context_between_sections", args: []string{
+			"-s", "Code", "main.go", "-s", "Environment", "--system-context",
+		}},
+		{name: "167_system_context_twice", args: []string{"--system-context", "main.go", "--system-context"}},
+		{name: "168_system_context_with_tree", args: []string{"--system-context", "-t", "src"}},
+		{name: "169_system_context_short_flag", args: []string{"-E", "main.go"}},
+	})
+}

--- a/cmd/lx/golden_runner.go
+++ b/cmd/lx/golden_runner.go
@@ -217,6 +217,13 @@ func normalizeOutput(stdout, stderr string, roots ...string) string {
 		s = regexp.MustCompile(`time=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+(?:[+-]\d{2}:\d{2}|Z)`).ReplaceAllString(s, "time=FIXED")
 		s = regexp.MustCompile(`msg="Loaded global ignore file" path=.*`).ReplaceAllString(s, `msg="Loaded global ignore file" path=GLOBAL_IGNORE`)
 
+		// --system-context reports the host machine and the current time.
+		s = regexp.MustCompile(`(?m)^OS: .*$`).ReplaceAllString(s, "OS: GOOS")
+		s = regexp.MustCompile(`(?m)^Arch: .*$`).ReplaceAllString(s, "Arch: GOARCH")
+		s = regexp.MustCompile(`(?m)^Time: .*$`).ReplaceAllString(s, "Time: FIXED")
+		s = regexp.MustCompile(`(?m)^Host: .*$`).ReplaceAllString(s, "Host: HOST")
+		s = regexp.MustCompile(`(?m)^Tool: lx .*$`).ReplaceAllString(s, "Tool: lx VERSION")
+
 		return s
 	}
 

--- a/cmd/lx/testdata/golden/160_system_context_only.golden
+++ b/cmd/lx/testdata/golden/160_system_context_only.golden
@@ -1,0 +1,12 @@
+--- STDOUT ---
+```
+OS: GOOS
+Arch: GOARCH
+Time: FIXED
+Host: HOST
+Tool: lx VERSION
+Command: lx --system-context --no-stats
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/161_system_context_before_files.golden
+++ b/cmd/lx/testdata/golden/161_system_context_before_files.golden
@@ -1,0 +1,19 @@
+--- STDOUT ---
+```
+OS: GOOS
+Arch: GOARCH
+Time: FIXED
+Host: HOST
+Tool: lx VERSION
+Command: lx --system-context main.go --no-stats
+```
+
+main.go (2 rows)
+---
+```go
+package main
+func main() {}
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/162_system_context_after_files.golden
+++ b/cmd/lx/testdata/golden/162_system_context_after_files.golden
@@ -1,0 +1,19 @@
+--- STDOUT ---
+main.go (2 rows)
+---
+```go
+package main
+func main() {}
+```
+
+```
+OS: GOOS
+Arch: GOARCH
+Time: FIXED
+Host: HOST
+Tool: lx VERSION
+Command: lx main.go --system-context --no-stats
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/163_system_context_xml.golden
+++ b/cmd/lx/testdata/golden/163_system_context_xml.golden
@@ -1,0 +1,22 @@
+--- STDOUT ---
+<content>
+  <system_context>
+OS: GOOS
+Arch: GOARCH
+Time: FIXED
+Host: HOST
+Tool: lx VERSION
+Command: lx --xml --system-context main.go --no-stats
+  </system_context>
+
+  <document index="1" language="go" rows="2">
+    <source>main.go</source>
+    <document_content>
+package main
+func main() {}
+    </document_content>
+  </document>
+</content>
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/164_system_context_bare.golden
+++ b/cmd/lx/testdata/golden/164_system_context_bare.golden
@@ -1,0 +1,5 @@
+--- STDOUT ---
+package main
+func main() {}
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/165_system_context_html.golden
+++ b/cmd/lx/testdata/golden/165_system_context_html.golden
@@ -1,0 +1,71 @@
+--- STDOUT ---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>lx Output</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.classless.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" media="(prefers-color-scheme: light)">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" media="(prefers-color-scheme: dark)">
+<style>
+.hljs { background: transparent !important; }
+img { max-width: 100%; height: auto; }
+pre { background-color: transparent; border: none; }
+article > header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background-color: var(--pico-card-background-color); 
+  border-bottom: 1px solid var(--pico-muted-border-color);
+}
+.file-anchor {
+  text-decoration: none;
+  color: var(--pico-muted-color);
+  margin-right: 0.5rem;
+  font-weight: bold;
+  border: none;
+}
+.file-anchor:hover {
+  color: var(--pico-primary);
+  text-decoration: underline;
+}
+.error-state { color: var(--pico-color-red-500); font-weight: bold; }
+</style>
+</head>
+<body>
+<header>
+<hgroup>
+<h1>lx output</h1>
+<p>
+  Files: 1 &bull; 
+  Size: 27 B &bull; 
+  Path: .
+</p>
+</hgroup>
+</header>
+<main>
+<pre class="system-context">OS: linux
+Arch: GOARCH
+Time: FIXED
+Host: HOST
+Tool: lx VERSION
+Command: lx --html --system-context main.go --no-stats
+</pre><article id="file-1">
+<header>
+ <a href="#file-1" aria-label="Link to this file"><strong>main.go</strong></a>
+ <small>(2 rows)</small>
+</header>
+<pre><code class="language-go">
+package main
+func main() {}
+</code></pre>
+</article>
+</section></main>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+<script>hljs.highlightAll();</script>
+</body>
+</html>
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/166_system_context_between_sections.golden
+++ b/cmd/lx/testdata/golden/166_system_context_between_sections.golden
@@ -1,0 +1,25 @@
+--- STDOUT ---
+## Code
+---
+
+main.go (2 rows)
+---
+```go
+package main
+func main() {}
+```
+
+## Environment
+---
+
+```
+OS: GOOS
+Arch: GOARCH
+Time: FIXED
+Host: HOST
+Tool: lx VERSION
+Command: lx -s Code main.go -s Environment --system-context --no-stats
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/167_system_context_twice.golden
+++ b/cmd/lx/testdata/golden/167_system_context_twice.golden
@@ -1,0 +1,28 @@
+--- STDOUT ---
+```
+OS: GOOS
+Arch: GOARCH
+Time: FIXED
+Host: HOST
+Tool: lx VERSION
+Command: lx --system-context main.go --system-context --no-stats
+```
+
+main.go (2 rows)
+---
+```go
+package main
+func main() {}
+```
+
+```
+OS: GOOS
+Arch: GOARCH
+Time: FIXED
+Host: HOST
+Tool: lx VERSION
+Command: lx --system-context main.go --system-context --no-stats
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/168_system_context_with_tree.golden
+++ b/cmd/lx/testdata/golden/168_system_context_with_tree.golden
@@ -1,0 +1,17 @@
+--- STDOUT ---
+```
+OS: GOOS
+Arch: GOARCH
+Time: FIXED
+Host: HOST
+Tool: lx VERSION
+Command: lx --system-context -t src --no-stats
+```
+
+```
+src/
+└── script.py
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/169_system_context_short_flag.golden
+++ b/cmd/lx/testdata/golden/169_system_context_short_flag.golden
@@ -1,0 +1,19 @@
+--- STDOUT ---
+```
+OS: GOOS
+Arch: GOARCH
+Time: FIXED
+Host: HOST
+Tool: lx VERSION
+Command: lx -E main.go --no-stats
+```
+
+main.go (2 rows)
+---
+```go
+package main
+func main() {}
+```
+
+
+--- STDERR ---

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/atotto/clipboard"
 	"github.com/rasros/lx/pkg/lx"
@@ -41,7 +42,7 @@ func Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("input gathering failed: %w", err)
 	}
 
-	return processStream(ctx, parsed)
+	return processStream(ctx, parsed, args)
 }
 
 func handleGlobals(parsed *ParsedArgs) bool {
@@ -74,7 +75,7 @@ func handleGlobals(parsed *ParsedArgs) bool {
 func gatherInputs(parsed *ParsedArgs) error {
 	hasFilesOrGenerators := false
 	for _, op := range parsed.Ops {
-		if op.Action == "FILE" || op.Action == "file" || op.Action == "section" || op.Action == "prompt" || op.Action == "prompt-file" {
+		if op.Action == "FILE" || op.Action == "file" || op.Action == "section" || op.Action == "prompt" || op.Action == "prompt-file" || op.Action == "system-context" {
 			slog.Debug("Detected input from actions")
 			hasFilesOrGenerators = true
 			break
@@ -105,7 +106,7 @@ func gatherInputs(parsed *ParsedArgs) error {
 	return nil
 }
 
-func processStream(ctx context.Context, parsed *ParsedArgs) error {
+func processStream(ctx context.Context, parsed *ParsedArgs, rawArgs []string) error {
 	initialLevel, err := determineLogLevel(parsed, "warn")
 	if err != nil {
 		return err
@@ -172,6 +173,15 @@ func processStream(ctx context.Context, parsed *ParsedArgs) error {
 	applyWorkloadConcurrency(stream, sections, runtime.NumCPU())
 	precomputeTrees(ctx, sections, globalIgnoreRules)
 	debugLoggingEnabled := slog.Default().Enabled(ctx, slog.LevelDebug)
+
+	var metaFields map[string]string
+	var metaBody string
+	resolveSystemContext := func() (map[string]string, string) {
+		if metaFields == nil {
+			metaFields, metaBody = systemContext(rawArgs, time.Now())
+		}
+		return metaFields, metaBody
+	}
 
 	for si, section := range sections {
 		slog.Debug("Processing section", "index", si, "ops", len(section.Ops))
@@ -446,6 +456,10 @@ func processStream(ctx context.Context, parsed *ParsedArgs) error {
 			case "section":
 				slog.Debug("Adding section", "title", op.Value)
 				stream.AddSection(op.Value)
+			case "system-context":
+				fields, body := resolveSystemContext()
+				slog.Debug("Adding system context", "fields", len(fields))
+				stream.AddMeta(body, fields)
 			case "prompt":
 				slog.Debug("Adding prompt", "length", len(op.Value))
 				stream.AddPrompt(op.Value)

--- a/internal/cli/defs.go
+++ b/internal/cli/defs.go
@@ -439,6 +439,31 @@ The second -s resets -l so web/ gets full content, with only -i active.`,
 	},
 	{
 		Category:  CatActions,
+		Name:      "system-context",
+		Short:     "E",
+		Type:      CmdAction,
+		ValueType: ValueNone,
+		Usage:     "Insert a block describing the machine and invocation",
+		Long: `Insert a block describing the machine and the command that produced the
+output.
+
+The block is placed where the flag appears, like -p and -T, so it can open the
+bundle or close it. It records the OS and architecture, the current time in
+ISO 8601, the hostname, the lx version, and the command line.
+
+This is for reproducibility: when you revisit a saved bundle weeks later, or
+collect context on several machines, the block says which environment the paths
+and tooling belong to. Platform-specific paths such as /nix/store/... are
+otherwise ambiguous.
+
+Example:
+  lx --system-context -t ./project -o context.md
+
+Every field is also available individually to a custom meta_template as
+{{ .Fields.os }}, {{ .Fields.time }}, and so on. See CONFIG.md.`,
+	},
+	{
+		Category:  CatActions,
 		Name:      "prompt",
 		Short:     "p",
 		Type:      CmdAction,

--- a/internal/cli/meta.go
+++ b/internal/cli/meta.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+// systemContext returns the fields for a --system-context block and the
+// pre-rendered body built from them.
+func systemContext(args []string, now time.Time) (map[string]string, string) {
+	fields := map[string]string{
+		"os":      runtime.GOOS,
+		"arch":    runtime.GOARCH,
+		"time":    now.Format(time.RFC3339),
+		"version": Version,
+		"command": formatCommand(args),
+	}
+	if host, err := os.Hostname(); err == nil && host != "" {
+		fields["host"] = host
+	}
+	return fields, systemContextBody(fields)
+}
+
+// Ordered so the block reads consistently; unknown keys from a caller-supplied
+// map are appended alphabetically rather than dropped.
+var systemContextOrder = []struct {
+	key    string
+	label  string
+	prefix string
+}{
+	{"os", "OS", ""},
+	{"arch", "Arch", ""},
+	{"time", "Time", ""},
+	{"host", "Host", ""},
+	{"version", "Tool", "lx "},
+	{"command", "Command", ""},
+}
+
+func systemContextBody(fields map[string]string) string {
+	var sb strings.Builder
+	seen := make(map[string]bool, len(systemContextOrder))
+
+	for _, f := range systemContextOrder {
+		seen[f.key] = true
+		if v := fields[f.key]; v != "" {
+			fmt.Fprintf(&sb, "%s: %s%s\n", f.label, f.prefix, v)
+		}
+	}
+
+	extra := make([]string, 0, len(fields))
+	for k := range fields {
+		if !seen[k] && fields[k] != "" {
+			extra = append(extra, k)
+		}
+	}
+	sort.Strings(extra)
+	for _, k := range extra {
+		fmt.Fprintf(&sb, "%s: %s\n", k, fields[k])
+	}
+
+	return sb.String()
+}
+
+// formatCommand renders the invocation for the block, quoting only arguments
+// that would otherwise be ambiguous to read back.
+func formatCommand(args []string) string {
+	parts := make([]string, 0, len(args)+1)
+	parts = append(parts, "lx")
+	for _, a := range args {
+		if a == "" || strings.ContainsAny(a, " \t\"'") {
+			parts = append(parts, fmt.Sprintf("%q", a))
+			continue
+		}
+		parts = append(parts, a)
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/cli/meta_test.go
+++ b/internal/cli/meta_test.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSystemContextFields(t *testing.T) {
+	at := time.Date(2026, 7, 19, 14, 55, 0, 0, time.UTC)
+	fields, _ := systemContext([]string{"-D", "-t", "./project"}, at)
+
+	if got := fields["os"]; got != runtime.GOOS {
+		t.Errorf("os = %q, want %q", got, runtime.GOOS)
+	}
+	if got := fields["arch"]; got != runtime.GOARCH {
+		t.Errorf("arch = %q, want %q", got, runtime.GOARCH)
+	}
+	if got := fields["time"]; got != "2026-07-19T14:55:00Z" {
+		t.Errorf("time = %q, want the injected timestamp", got)
+	}
+	if got := fields["version"]; got != Version {
+		t.Errorf("version = %q, want %q", got, Version)
+	}
+	if got := fields["command"]; got != "lx -D -t ./project" {
+		t.Errorf("command = %q", got)
+	}
+}
+
+func TestSystemContextBodyOrderAndLabels(t *testing.T) {
+	body := systemContextBody(map[string]string{
+		"command": "lx .",
+		"version": "v1.2.3",
+		"host":    "workstation",
+		"time":    "2026-07-19T14:55:00Z",
+		"arch":    "amd64",
+		"os":      "linux",
+	})
+
+	want := strings.Join([]string{
+		"OS: linux",
+		"Arch: amd64",
+		"Time: 2026-07-19T14:55:00Z",
+		"Host: workstation",
+		"Tool: lx v1.2.3",
+		"Command: lx .",
+	}, "\n") + "\n"
+
+	if body != want {
+		t.Errorf("body =\n%q\nwant\n%q", body, want)
+	}
+}
+
+func TestSystemContextBodySkipsMissingFields(t *testing.T) {
+	body := systemContextBody(map[string]string{"os": "linux", "host": ""})
+
+	if strings.Contains(body, "Host:") {
+		t.Errorf("body includes an empty Host line:\n%q", body)
+	}
+	if !strings.Contains(body, "OS: linux") {
+		t.Errorf("body missing OS line:\n%q", body)
+	}
+}
+
+func TestSystemContextBodyAppendsUnknownFieldsAlphabetically(t *testing.T) {
+	body := systemContextBody(map[string]string{
+		"os":     "linux",
+		"zone":   "utc",
+		"branch": "main",
+	})
+
+	want := "OS: linux\nbranch: main\nzone: utc\n"
+	if body != want {
+		t.Errorf("body =\n%q\nwant\n%q", body, want)
+	}
+}
+
+func TestFormatCommandQuotesAmbiguousArguments(t *testing.T) {
+	cases := []struct {
+		args []string
+		want string
+	}{
+		{[]string{}, "lx"},
+		{[]string{"-i", "*.go", "."}, "lx -i *.go ."},
+		{[]string{"-s", "My Section"}, `lx -s "My Section"`},
+		{[]string{"-p", "it's here"}, `lx -p "it's here"`},
+		{[]string{""}, `lx ""`},
+	}
+
+	for _, c := range cases {
+		if got := formatCommand(c.args); got != c.want {
+			t.Errorf("formatCommand(%q) = %q, want %q", c.args, got, c.want)
+		}
+	}
+}

--- a/pkg/lx/facade.go
+++ b/pkg/lx/facade.go
@@ -156,6 +156,11 @@ func (s *Stream) AddTree(body string) *Stream {
 	return s
 }
 
+func (s *Stream) AddMeta(body string, fields map[string]string) *Stream {
+	s.inner.AddMeta(body, fields)
+	return s
+}
+
 func (s *Stream) Prepare() GlobalContext { return s.inner.Prepare() }
 
 func (s *Stream) GetGlobalContext() GlobalContext { return s.inner.GetGlobalContext() }

--- a/pkg/lx/render/processor.go
+++ b/pkg/lx/render/processor.go
@@ -130,6 +130,12 @@ func (p *Processor) RenderPrepared(w io.Writer, item PreparedItem, scratchBuf []
 		ctx = &v
 		templateToUse = p.engine.Tree
 
+	case core.MetaContext:
+		v.Global = p.global
+		v.Section = *item.Section
+		ctx = &v
+		templateToUse = p.engine.Meta
+
 	default:
 		return nil
 	}
@@ -376,6 +382,8 @@ func EstimatePreparedBufferSize(item PreparedItem) int {
 		}
 		return hint
 	case core.TreeContext:
+		return clampBodyHint(v.Body)
+	case core.MetaContext:
 		return clampBodyHint(v.Body)
 	case core.PromptContext:
 		return clampBodyHint(v.Body)

--- a/pkg/lx/streaming/stream.go
+++ b/pkg/lx/streaming/stream.go
@@ -111,6 +111,11 @@ func (s *Stream) AddTree(body string) *Stream {
 	return s
 }
 
+func (s *Stream) AddMeta(body string, fields map[string]string) *Stream {
+	s.items = append(s.items, core.MetaContext{Body: body, Fields: fields})
+	return s
+}
+
 // Prepare calculates metadata and organizes items into sections before rendering.
 func (s *Stream) Prepare() core.GlobalContext {
 	if s.finalStats != nil {


### PR DESCRIPTION
Adds `-E/--system-context`, an action that inserts a block describing the machine and invocation (OS, arch, ISO 8601 time, host, version, command line) at the position the flag appears, like `-p`/`-T`.

Every field is also exposed individually to a custom `meta_template` as `{{ .Fields.os }}` etc.

Part of #81.