### PR TITLE
refactor: extract processor seams for upcoming converters

### DIFF
--- a/pkg/lx/render/processor.go
+++ b/pkg/lx/render/processor.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
 	"text/template"
 
 	"github.com/rasros/lx/pkg/lx/core"
@@ -148,64 +150,87 @@ func (p *Processor) RenderPrepared(w io.Writer, item PreparedItem, scratchBuf []
 	return nil
 }
 
+// errorContext describes a file that could not be read.
+func (p *Processor) errorContext(file sources.InputFile, index int, msg string) core.FileContext {
+	return core.FileContext{
+		Path:         file.Path,
+		AbsPath:      file.AbsPath,
+		Size:         file.Size,
+		OriginalSize: file.Size,
+		ModTime:      file.ModTime,
+		FileIndex:    index,
+		Global:       p.global,
+		ReadError:    msg,
+		IsError:      true,
+	}
+}
+
+// readerFor adapts an opened file to random access, buffering the content only
+// when the reader cannot provide it directly. Cases are ordered most to least
+// specific.
+func readerFor(rc io.ReadCloser, sizeHint int64) (io.ReaderAt, int64) {
+	switch v := rc.(type) {
+	case *os.File:
+		return v, sizeHint
+	case byteReaderProvider:
+		br := v.ByteReader()
+		return br, br.Size()
+	case readerAtWithSize:
+		return v, v.Size()
+	case io.ReaderAt:
+		return v, sizeHint
+	}
+	data, _ := io.ReadAll(rc)
+	return bytes.NewReader(data), int64(len(data))
+}
+
+// convert replaces file content with a text rendering of it when a converter
+// applies, and reports the format converted from. A converter that fails leaves
+// the content untouched.
+func convert(file sources.InputFile, reader io.ReaderAt, size int64) (io.ReaderAt, int64, string) {
+	if file.Config.ExtractDocuments && sources.IsDocumentPath(file.Path) {
+		text, err := sources.ExtractDocumentText(file.Path, reader, size)
+		if err != nil {
+			return reader, size, ""
+		}
+		return bytes.NewReader(text), int64(len(text)), fileFormat(file.Path)
+	}
+	return reader, size, ""
+}
+
+func fileFormat(path string) string {
+	return strings.TrimPrefix(strings.ToLower(filepath.Ext(path)), ".")
+}
+
+func skeletonModeLabel(functions, types bool) string {
+	switch {
+	case functions && types:
+		return "definitions"
+	case functions:
+		return "function signatures"
+	default:
+		return "type definitions"
+	}
+}
+
 func (p *Processor) prepareFileContext(file sources.InputFile, index int, scratch []byte) (core.FileContext, error) {
 	rc, err := file.Open()
 	if err != nil {
 		if p.onFileError != nil {
 			p.onFileError(file, err)
 		}
-		return core.FileContext{
-			Path:         file.Path,
-			AbsPath:      file.AbsPath,
-			Size:         file.Size,
-			OriginalSize: file.Size,
-			ModTime:      file.ModTime,
-			FileIndex:    index,
-			Global:       p.global,
-			ReadError:    err.Error(),
-			IsError:      true,
-		}, nil
+		return p.errorContext(file, index, err.Error()), nil
 	}
 	defer rc.Close()
 
 	if f, ok := rc.(*os.File); ok {
 		if stat, err := f.Stat(); err == nil && stat.IsDir() {
-			return core.FileContext{
-				Path:         file.Path,
-				AbsPath:      file.AbsPath,
-				Size:         file.Size,
-				OriginalSize: file.Size,
-				ModTime:      file.ModTime,
-				FileIndex:    index,
-				Global:       p.global,
-				ReadError:    "is a directory",
-				IsError:      true,
-			}, nil
+			return p.errorContext(file, index, "is a directory"), nil
 		}
 	}
 
-	var reader io.ReaderAt
-	var size int64
-	if f, ok := rc.(*os.File); ok {
-		reader, size = f, file.Size
-	} else if brp, ok := rc.(byteReaderProvider); ok {
-		br := brp.ByteReader()
-		reader, size = br, br.Size()
-	} else if ras, ok := rc.(readerAtWithSize); ok {
-		reader, size = ras, ras.Size()
-	} else if ra, ok := rc.(io.ReaderAt); ok {
-		reader, size = ra, file.Size
-	} else {
-		data, _ := io.ReadAll(rc)
-		reader, size = bytes.NewReader(data), int64(len(data))
-	}
-
-	if file.Config.ExtractDocuments && sources.IsDocumentPath(file.Path) {
-		if text, err := sources.ExtractDocumentText(file.Path, reader, size); err == nil {
-			reader = bytes.NewReader(text)
-			size = int64(len(text))
-		}
-	}
+	reader, size := readerFor(rc, file.Size)
+	reader, size, convertedFrom := convert(file, reader, size)
 
 	if scratch == nil {
 		scratch = make([]byte, 1024)
@@ -234,14 +259,7 @@ func (p *Processor) prepareFileContext(file sources.InputFile, index int, scratc
 				headerLen = int(size)
 			}
 			n, _ = reader.ReadAt(scratch[:headerLen], 0)
-			switch {
-			case cfg.SkeletonFunctions && cfg.SkeletonTypes:
-				skeletonMode = "definitions"
-			case cfg.SkeletonFunctions:
-				skeletonMode = "function signatures"
-			default:
-				skeletonMode = "type definitions"
-			}
+			skeletonMode = skeletonModeLabel(cfg.SkeletonFunctions, cfg.SkeletonTypes)
 		}
 	}
 
@@ -265,17 +283,7 @@ func (p *Processor) prepareFileContext(file sources.InputFile, index int, scratc
 
 		head, tail, gap, err := p.readSlices(reader, size, totalRows, !exact, effectiveCfg)
 		if err != nil {
-			return core.FileContext{
-				Path:         file.Path,
-				AbsPath:      file.AbsPath,
-				Size:         file.Size,
-				OriginalSize: file.Size,
-				ModTime:      file.ModTime,
-				FileIndex:    index,
-				Global:       p.global,
-				ReadError:    err.Error(),
-				IsError:      true,
-			}, nil
+			return p.errorContext(file, index, err.Error()), nil
 		}
 		contentData = p.formatContent(head, tail, gap, totalRows, effectiveCfg)
 	}
@@ -296,6 +304,7 @@ func (p *Processor) prepareFileContext(file sources.InputFile, index int, scratc
 		FileIndex:     index,
 		Global:        p.global,
 		SkeletonMode:  skeletonMode,
+		ConvertedFrom: convertedFrom,
 	}, nil
 }
 

--- a/pkg/lx/render/processor_test.go
+++ b/pkg/lx/render/processor_test.go
@@ -199,3 +199,50 @@ func TestRender_LineNumbers(t *testing.T) {
 		t.Errorf("Expected line numbers in output, got:\n%s", got)
 	}
 }
+
+func TestSkeletonModeLabel(t *testing.T) {
+	cases := []struct {
+		functions, types bool
+		want             string
+	}{
+		{true, true, "definitions"},
+		{true, false, "function signatures"},
+		{false, true, "type definitions"},
+	}
+	for _, c := range cases {
+		if got := skeletonModeLabel(c.functions, c.types); got != c.want {
+			t.Errorf("skeletonModeLabel(%v, %v) = %q, want %q", c.functions, c.types, got, c.want)
+		}
+	}
+}
+
+func TestReaderForBuffersNonSeekableReaders(t *testing.T) {
+	// A plain ReadCloser exposes neither ReaderAt nor Size, so it must be read
+	// into memory and reported at its true length rather than the hint.
+	rc := io.NopCloser(strings.NewReader("hello world"))
+	reader, size := readerFor(rc, 999)
+
+	if size != 11 {
+		t.Errorf("size = %d, want 11", size)
+	}
+	buf := make([]byte, size)
+	if _, err := reader.ReadAt(buf, 0); err != nil {
+		t.Fatalf("ReadAt failed: %v", err)
+	}
+	if string(buf) != "hello world" {
+		t.Errorf("content = %q", buf)
+	}
+}
+
+func TestFileFormat(t *testing.T) {
+	cases := map[string]string{
+		"a/b/manual.PDF": "pdf",
+		"notes.docx":     "docx",
+		"Makefile":       "",
+	}
+	for path, want := range cases {
+		if got := fileFormat(path); got != want {
+			t.Errorf("fileFormat(%q) = %q, want %q", path, got, want)
+		}
+	}
+}

--- a/pkg/lx/streaming/document_test.go
+++ b/pkg/lx/streaming/document_test.go
@@ -88,3 +88,41 @@ func TestStream_ExtractDocuments_EnabledViaRunnerConfig(t *testing.T) {
 		t.Errorf("extraction should be enabled by default, got:\n%s", got)
 	}
 }
+
+func TestStream_ConvertedFromNamesTheSourceFormat(t *testing.T) {
+	cfg := core.NewConfig()
+	cfg.FileContentTemplate = "[{{ .ConvertedFrom }}]"
+	stream, err := NewStream(cfg, core.RunnerConfig{Head: -1, ExtractDocuments: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stream.AddFile(sources.NewBufferInputFile("doc.docx", makeTestDOCX(t, "Content")))
+
+	var buf strings.Builder
+	if err := stream.Execute(context.Background(), &buf); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(buf.String()); got != "[docx]" {
+		t.Errorf("ConvertedFrom rendered as %q, want %q", got, "[docx]")
+	}
+}
+
+func TestStream_ConvertedFromEmptyWithoutAConverter(t *testing.T) {
+	cfg := core.NewConfig()
+	cfg.FileContentTemplate = "[{{ .ConvertedFrom }}]"
+	stream, err := NewStream(cfg, core.RunnerConfig{Head: -1})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stream.AddFile(sources.NewBufferInputFile("main.go", []byte("package main\n")))
+
+	var buf strings.Builder
+	if err := stream.Execute(context.Background(), &buf); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(buf.String()); got != "[]" {
+		t.Errorf("ConvertedFrom rendered as %q, want empty", got)
+	}
+}


### PR DESCRIPTION
Prepares `prepareFileContext` for the HTML and media converters by extracting its seams: `errorContext` (three identical 10-field literals), `readerFor` (the five-branch reader ladder), `convert` (the converter step both features extend), and `skeletonModeLabel`.

Also populates `FileContext.ConvertedFrom` for `-D`, which has been unfilled since #84.

Behaviour-preserving — no golden file moved.

Part of #81.