### PR TITLE
fix: honor piped file lists alongside generator flags

### DIFF
--- a/cmd/lx/golden_core_test.go
+++ b/cmd/lx/golden_core_test.go
@@ -106,6 +106,8 @@ func TestGoldenErrors(t *testing.T) {
 		{name: "065_stdin_content", args: []string{"-"}, stdin: "Some content from pipe\nLine 2"},
 		{name: "066_stdin_and_files", args: []string{"main.go", "-"}, stdin: "Piped content"},
 		{name: "067_stdin_file_list", args: []string{}, stdin: "main.go\nREADME.md"},
+		{name: "068_stdin_file_list_with_prompt", args: []string{"-p", "Review these"}, stdin: "main.go\nREADME.md"},
+		{name: "069_stdin_file_list_with_system_context", args: []string{"-E"}, stdin: "main.go"},
 	})
 }
 

--- a/cmd/lx/golden_maxsize_test.go
+++ b/cmd/lx/golden_maxsize_test.go
@@ -19,6 +19,7 @@ func TestGoldenMaxSize(t *testing.T) {
 		{name: "147_max_size_per_section_override", args: []string{"-m", "20", ".", "-m", "2k", "src/large.txt"}},
 		{name: "148_max_size_invalid_value", args: []string{"-m", "notasize", "."}},
 		{name: "149_max_size_attached_short_form", args: []string{"-m1k", "."}},
+		{name: "152_max_size_zero_rejected", args: []string{"-m", "0", "."}},
 	})
 }
 

--- a/cmd/lx/testdata/golden/068_stdin_file_list_with_prompt.golden
+++ b/cmd/lx/testdata/golden/068_stdin_file_list_with_prompt.golden
@@ -1,0 +1,20 @@
+--- STDOUT ---
+Review these
+
+
+[1/2] main.go (2 rows)
+---
+```go
+package main
+func main() {}
+```
+
+[2/2] README.md (2 rows)
+---
+```markdown
+# Project
+Documentation here.
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/069_stdin_file_list_with_system_context.golden
+++ b/cmd/lx/testdata/golden/069_stdin_file_list_with_system_context.golden
@@ -1,0 +1,19 @@
+--- STDOUT ---
+```
+OS: GOOS
+Arch: GOARCH
+Time: FIXED
+Host: HOST
+Tool: lx VERSION
+Command: lx -E --no-stats
+```
+
+main.go (2 rows)
+---
+```go
+package main
+func main() {}
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/072_verbose_debug.golden
+++ b/cmd/lx/testdata/golden/072_verbose_debug.golden
@@ -17,5 +17,5 @@ time=FIXED level=DEBUG msg="Output set to stdout"
 time=FIXED level=DEBUG msg="Processing op" action=FILE value=main.go
 time=FIXED level=DEBUG msg="Processing operations" total_ops=4
 time=FIXED level=DEBUG msg="Processing section" index=0 ops=1
-time=FIXED level=DEBUG msg="Walker finished" root=main.go files_found=1
+time=FIXED level=DEBUG msg="Walker finished" root=main.go files_matched=1
 time=FIXED level=INFO msg="Executing stream pipeline..."

--- a/cmd/lx/testdata/golden/073_verbose_flag.golden
+++ b/cmd/lx/testdata/golden/073_verbose_flag.golden
@@ -17,5 +17,5 @@ time=FIXED level=DEBUG msg="Output set to stdout"
 time=FIXED level=DEBUG msg="Processing op" action=FILE value=main.go
 time=FIXED level=DEBUG msg="Processing operations" total_ops=3
 time=FIXED level=DEBUG msg="Processing section" index=0 ops=1
-time=FIXED level=DEBUG msg="Walker finished" root=main.go files_found=1
+time=FIXED level=DEBUG msg="Walker finished" root=main.go files_matched=1
 time=FIXED level=INFO msg="Executing stream pipeline..."

--- a/cmd/lx/testdata/golden/148_max_size_invalid_value.golden
+++ b/cmd/lx/testdata/golden/148_max_size_invalid_value.golden
@@ -2,4 +2,4 @@
 
 
 --- STDERR ---
-CLI Error: argument parsing failed: flag --max-size expects a size like 512k or 2M, got "notasize"
+CLI Error: argument parsing failed: flag --max-size: invalid size "notasize", expected a byte count like 512k or 2M

--- a/cmd/lx/testdata/golden/152_max_size_zero_rejected.golden
+++ b/cmd/lx/testdata/golden/152_max_size_zero_rejected.golden
@@ -1,0 +1,5 @@
+--- STDOUT ---
+
+
+--- STDERR ---
+CLI Error: argument parsing failed: flag --max-size: size must be greater than zero

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -73,16 +73,23 @@ func handleGlobals(parsed *ParsedArgs) bool {
 }
 
 func gatherInputs(parsed *ParsedArgs) error {
-	hasFilesOrGenerators := false
+	// Stdin depends only on explicit file arguments; the "." fallback also
+	// depends on generators, which already give the run something to emit.
+	hasFiles := false
+	hasGenerators := false
 	for _, op := range parsed.Ops {
-		if op.Action == "FILE" || op.Action == "file" || op.Action == "section" || op.Action == "prompt" || op.Action == "prompt-file" || op.Action == "system-context" {
-			slog.Debug("Detected input from actions")
-			hasFilesOrGenerators = true
-			break
+		switch op.Action {
+		case "FILE", "file":
+			hasFiles = true
+		case "section", "prompt", "prompt-file", "system-context":
+			hasGenerators = true
 		}
 	}
+	if hasFiles {
+		slog.Debug("Detected input from file actions")
+	}
 
-	if !hasFilesOrGenerators {
+	if !hasFiles {
 		_, useNull := parsed.Globals["null"]
 		stdinFiles, isPipe, err := readFilenamesFromStdin(useNull)
 		if err != nil {
@@ -93,13 +100,13 @@ func gatherInputs(parsed *ParsedArgs) error {
 			for _, f := range stdinFiles {
 				parsed.Ops = append(parsed.Ops, Op{Action: "FILE", Value: f, Type: CmdAction})
 			}
-			hasFilesOrGenerators = true
+			hasFiles = true
 		} else {
 			slog.Debug("No stdin pipe detected")
 		}
 	}
 
-	if !hasFilesOrGenerators {
+	if !hasFiles && !hasGenerators {
 		slog.Debug("No inputs detected, defaulting to current directory '.'")
 		parsed.Ops = append(parsed.Ops, Op{Action: "FILE", Value: ".", Type: CmdAction})
 	}
@@ -444,7 +451,7 @@ func processStream(ctx context.Context, parsed *ParsedArgs, rawArgs []string) er
 				if err != nil {
 					slog.Error("Walker traversal failed", "error", err)
 				}
-				slog.Debug("Walker finished", "root", rawPath, "files_found", count)
+				slog.Debug("Walker finished", "root", rawPath, "files_matched", count)
 
 			case "tree", "tree-only":
 				if ts, ok := section.treeStrings[oi]; ok {

--- a/internal/cli/args.go
+++ b/internal/cli/args.go
@@ -222,7 +222,7 @@ func addOp(res *ParsedArgs, def CommandDef, val string, isShort bool) error {
 		}
 	case ValueSize:
 		if _, err := parseSizeLimit(val); err != nil {
-			return fmt.Errorf("flag %s%s expects a size like 512k or 2M, got %q", prefix, def.Name, val)
+			return fmt.Errorf("flag %s%s: %w", prefix, def.Name, err)
 		}
 	}
 

--- a/internal/cli/defs.go
+++ b/internal/cli/defs.go
@@ -233,6 +233,9 @@ and case-insensitive, matching how lx reports sizes elsewhere:
   -m 2MB      (2 MB)
   -m 1G       (1 GB)
 
+The value must be greater than zero; there is no "unlimited" spelling, simply
+omit the flag.
+
 The limit applies to every input, including paths forced with -f. Inputs whose
 size is not known ahead of time, such as remote URLs, are never skipped.`,
 	},

--- a/internal/cli/size.go
+++ b/internal/cli/size.go
@@ -41,10 +41,13 @@ func parseSizeLimit(raw string) (int64, error) {
 
 	n, err := strconv.ParseInt(lower, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("invalid size %q", raw)
+		return 0, fmt.Errorf("invalid size %q, expected a byte count like 512k or 2M", raw)
 	}
 	if n < 0 {
 		return 0, fmt.Errorf("size cannot be negative: %q", raw)
+	}
+	if n == 0 {
+		return 0, fmt.Errorf("size must be greater than zero")
 	}
 	if mult > 1 && n > (1<<62)/mult {
 		return 0, fmt.Errorf("size out of range: %q", raw)

--- a/internal/cli/size_test.go
+++ b/internal/cli/size_test.go
@@ -11,7 +11,6 @@ func TestParseSizeLimit(t *testing.T) {
 		in   string
 		want int64
 	}{
-		{"0", 0},
 		{"1", 1},
 		{"4096", 4096},
 		{"512k", 512_000},
@@ -48,6 +47,8 @@ func TestParseSizeLimitErrors(t *testing.T) {
 		"notasize",
 		"k",
 		"kb",
+		"0",
+		"0k",
 		"-1",
 		"-5k",
 		"1.5M",

--- a/pkg/lx/render/processor.go
+++ b/pkg/lx/render/processor.go
@@ -255,10 +255,6 @@ func (p *Processor) prepareFileContext(file sources.InputFile, index int, scratc
 			filtered := skeleton.Extract(lang, allData, cfg.SkeletonFunctions, cfg.SkeletonTypes)
 			reader = bytes.NewReader(filtered)
 			size = int64(len(filtered))
-			if int64(headerLen) > size {
-				headerLen = int(size)
-			}
-			n, _ = reader.ReadAt(scratch[:headerLen], 0)
 			skeletonMode = skeletonModeLabel(cfg.SkeletonFunctions, cfg.SkeletonTypes)
 		}
 	}


### PR DESCRIPTION
Four fixes found while reviewing the recent work:

- `git ls-files | lx -p "..."` silently discarded the piped file list. Reading stdin now depends only on explicit file arguments; falling back to `.` still depends on generators too. Affects `-p`, `-P`, `-s`, `-E`.
- `-m 0` silently disabled the size guard instead of being rejected, and size errors now report the actual reason.
- Removed a dead 1 KB read per skeleton-filtered file (`EstimateLineCount` immediately overwrites the buffer).
- `Walker finished` logged `files_found`, which counted files the stream later dropped; renamed to `files_matched`.