### PR TITLE
fix: escape line-numbered content in html output

### DIFF
--- a/cmd/lx/golden_core_test.go
+++ b/cmd/lx/golden_core_test.go
@@ -138,6 +138,8 @@ func TestGoldenDetection(t *testing.T) {
 		{name: "086_render_image_md", args: []string{"assets/logo.png"}},
 		{name: "087_render_image_html", args: []string{"--html", "assets/logo.png"}},
 		{name: "088_render_image_compact", args: []string{"-n0", "assets/logo.png"}},
+		{name: "089_html_escapes_markup", args: []string{"--html", "langs/page.html"}},
+		{name: "089b_html_escapes_markup_line_numbers", args: []string{"--html", "-l", "langs/page.html"}},
 	})
 }
 

--- a/cmd/lx/goldenfixtures/core.go
+++ b/cmd/lx/goldenfixtures/core.go
@@ -144,6 +144,7 @@ func SetupDetectionFixture(t *testing.T) string {
 	writeFile(t, dir, "langs/script_no_ext", "#!/bin/bash\necho hi", 0755)
 	writeFile(t, dir, "src/script.py", "print('hello')", 0755)
 	writeFile(t, dir, "assets/logo.png", "\x89PNG\r\n\x1a\n\x00\x00\x00\x0D", 0644)
+	writeFile(t, dir, "langs/page.html", "<script>alert(1)</script>\n<p>hi &amp; bye</p>", 0644)
 
 	return dir
 }

--- a/cmd/lx/testdata/golden/089_html_escapes_markup.golden
+++ b/cmd/lx/testdata/golden/089_html_escapes_markup.golden
@@ -1,0 +1,65 @@
+--- STDOUT ---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>lx Output</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.classless.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" media="(prefers-color-scheme: light)">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" media="(prefers-color-scheme: dark)">
+<style>
+.hljs { background: transparent !important; }
+img { max-width: 100%; height: auto; }
+pre { background-color: transparent; border: none; }
+article > header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background-color: var(--pico-card-background-color); 
+  border-bottom: 1px solid var(--pico-muted-border-color);
+}
+.file-anchor {
+  text-decoration: none;
+  color: var(--pico-muted-color);
+  margin-right: 0.5rem;
+  font-weight: bold;
+  border: none;
+}
+.file-anchor:hover {
+  color: var(--pico-primary);
+  text-decoration: underline;
+}
+.error-state { color: var(--pico-color-red-500); font-weight: bold; }
+</style>
+</head>
+<body>
+<header>
+<hgroup>
+<h1>lx output</h1>
+<p>
+  Files: 1 &bull; 
+  Size: 45 B &bull; 
+  Path: .
+</p>
+</hgroup>
+</header>
+<main>
+<article id="file-1">
+<header>
+ <a href="#file-1" aria-label="Link to this file"><strong>langs/page.html</strong></a>
+ <small>(2 rows)</small>
+</header>
+<pre><code class="language-html">
+&lt;script&gt;alert(1)&lt;/script&gt;
+&lt;p&gt;hi &amp;amp; bye&lt;/p&gt;
+</code></pre>
+</article>
+</section></main>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+<script>hljs.highlightAll();</script>
+</body>
+</html>
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/089b_html_escapes_markup_line_numbers.golden
+++ b/cmd/lx/testdata/golden/089b_html_escapes_markup_line_numbers.golden
@@ -1,0 +1,65 @@
+--- STDOUT ---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>lx Output</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.classless.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" media="(prefers-color-scheme: light)">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" media="(prefers-color-scheme: dark)">
+<style>
+.hljs { background: transparent !important; }
+img { max-width: 100%; height: auto; }
+pre { background-color: transparent; border: none; }
+article > header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background-color: var(--pico-card-background-color); 
+  border-bottom: 1px solid var(--pico-muted-border-color);
+}
+.file-anchor {
+  text-decoration: none;
+  color: var(--pico-muted-color);
+  margin-right: 0.5rem;
+  font-weight: bold;
+  border: none;
+}
+.file-anchor:hover {
+  color: var(--pico-primary);
+  text-decoration: underline;
+}
+.error-state { color: var(--pico-color-red-500); font-weight: bold; }
+</style>
+</head>
+<body>
+<header>
+<hgroup>
+<h1>lx output</h1>
+<p>
+  Files: 1 &bull; 
+  Size: 45 B &bull; 
+  Path: .
+</p>
+</hgroup>
+</header>
+<main>
+<article id="file-1">
+<header>
+ <a href="#file-1" aria-label="Link to this file"><strong>langs/page.html</strong></a>
+ <small>(2 rows)</small>
+</header>
+<pre><code class="language-html">
+1: &lt;script&gt;alert(1)&lt;/script&gt;
+2: &lt;p&gt;hi &amp;amp; bye&lt;/p&gt;
+</code></pre>
+</article>
+</section></main>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+<script>hljs.highlightAll();</script>
+</body>
+</html>
+
+--- STDERR ---

--- a/pkg/lx/core/token_test.go
+++ b/pkg/lx/core/token_test.go
@@ -118,3 +118,20 @@ func TestDefaultTokenCounter_LargeContentSampling(t *testing.T) {
 		t.Errorf("sampled=%d exact=%d diff=%d > tolerance=%d", sampled, exact, diff, tolerance)
 	}
 }
+
+type stringerContent struct{ s string }
+
+func (s stringerContent) String() string { return s.s }
+
+func TestDefaultTokenCounterUsesStringerContent(t *testing.T) {
+	content := stringerContent{s: strings.Repeat(`{"a":1},`, 90)}
+	size := int64(len(content.s))
+
+	got := DefaultTokenCounter(size, content)
+	if got == size/4 {
+		t.Errorf("estimate %d equals the size/4 fallback; Stringer content was not scanned", got)
+	}
+	if want := DefaultTokenCounter(size, content.s); got != want {
+		t.Errorf("Stringer estimate %d != equivalent string estimate %d", got, want)
+	}
+}

--- a/pkg/lx/internal/lines.go
+++ b/pkg/lx/internal/lines.go
@@ -18,6 +18,19 @@ type LineNumberFormatter struct {
 }
 
 func (lnf LineNumberFormatter) Format(f fmt.State, c rune) {
+	lnf.writeTo(f)
+}
+
+// String lets consumers that only understand text — template helpers, the token
+// counter — see the numbered content instead of falling back to %v.
+func (lnf LineNumberFormatter) String() string {
+	var buf bytes.Buffer
+	buf.Grow(len(lnf.Head) + len(lnf.Gap) + len(lnf.Tail))
+	lnf.writeTo(&buf)
+	return buf.String()
+}
+
+func (lnf LineNumberFormatter) writeTo(out io.Writer) {
 	width := 1
 	if lnf.TotalRows > 9 {
 		width = int(math.Log10(float64(lnf.TotalRows))) + 1
@@ -30,7 +43,7 @@ func (lnf LineNumberFormatter) Format(f fmt.State, c rune) {
 	printChunk := func(data []byte, startRow int) {
 		currentRow := startRow
 		offset := 0
-		write := func(b []byte) { f.Write(b) }
+		write := func(b []byte) { out.Write(b) }
 
 		for offset < len(data) {
 			idx := bytes.IndexByte(data[offset:], '\n')
@@ -64,7 +77,7 @@ func (lnf LineNumberFormatter) Format(f fmt.State, c rune) {
 	}
 
 	if len(lnf.Gap) > 0 {
-		f.Write(lnf.Gap)
+		out.Write(lnf.Gap)
 	}
 
 	if len(lnf.Tail) > 0 {

--- a/pkg/lx/internal/lines_test.go
+++ b/pkg/lx/internal/lines_test.go
@@ -139,3 +139,25 @@ func TestLineNumberFormatter(t *testing.T) {
 		t.Error("Missing double digit line number")
 	}
 }
+
+func TestLineNumberFormatterStringMatchesFormat(t *testing.T) {
+	lnf := LineNumberFormatter{
+		Head:      []byte("alpha\nbeta\n"),
+		Gap:       []byte("... (7 rows skipped)\n"),
+		Tail:      []byte("yankee\nzulu\n"),
+		TotalRows: 11,
+	}
+
+	viaFormat := fmt.Sprintf("%v", lnf)
+	if got := lnf.String(); got != viaFormat {
+		t.Errorf("String() = %q, want it to match Format output %q", got, viaFormat)
+	}
+}
+
+func TestLineNumberFormatterStringNumbersLines(t *testing.T) {
+	lnf := LineNumberFormatter{Head: []byte("one\ntwo\n"), TotalRows: 2}
+	want := "1: one\n2: two\n"
+	if got := lnf.String(); got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}

--- a/pkg/lx/templatex/contexts_test.go
+++ b/pkg/lx/templatex/contexts_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/rasros/lx/pkg/lx/core"
+	"github.com/rasros/lx/pkg/lx/internal"
 )
 
 func compileForFormat(t *testing.T, format string) *core.TemplateEngine {
@@ -113,5 +114,36 @@ func TestStatsCounterLineHasNoLeadingSeparator(t *testing.T) {
 	got := renderStats(t, core.GlobalContext{TotalFiles: 5, BinaryFiles: 3})
 	if !strings.Contains(got, "  3 binary\n") {
 		t.Errorf("stats counter line malformed:\n%q", got)
+	}
+}
+
+// Content is either a string or a LineNumberFormatter; helpers must treat both
+// alike. Reaching for %v on the formatter silently skipped escaping.
+func TestEscapeHandlesLineNumberedContent(t *testing.T) {
+	escape := templateFuncs()["escape"].(func(interface{}) string)
+
+	plain := escape("<script>alert(1)</script>\n")
+	numbered := escape(internal.LineNumberFormatter{
+		Head:      []byte("<script>alert(1)</script>\n"),
+		TotalRows: 1,
+	})
+
+	if strings.Contains(plain, "<script>") {
+		t.Errorf("string content not escaped: %q", plain)
+	}
+	if strings.Contains(numbered, "<script>") {
+		t.Errorf("line-numbered content not escaped: %q", numbered)
+	}
+	if !strings.Contains(numbered, "1: &lt;script&gt;") {
+		t.Errorf("line-numbered content lost its numbering or escaping: %q", numbered)
+	}
+}
+
+func TestEndNewlineHandlesLineNumberedContent(t *testing.T) {
+	endNewline := templateFuncs()["endNewline"].(func(interface{}) string)
+
+	got := endNewline(internal.LineNumberFormatter{Head: []byte("alpha"), TotalRows: 1})
+	if got != "1: alpha\n" {
+		t.Errorf("endNewline = %q, want %q", got, "1: alpha\n")
 	}
 }

--- a/pkg/lx/templatex/defaults.go
+++ b/pkg/lx/templatex/defaults.go
@@ -280,6 +280,21 @@ const defaultStatsTemplate = `{{ accent .ColorEnabled "▎" }} ` +
 	`{{ if .Global.FailedFiles }}{{ $sep }}{{ commafy .Global.FailedFiles }} failed{{ end }}` +
 	"\n" + `{{ end }}`
 
+// contentString renders template content as text. FileContext.Content is either
+// a string or a LineNumberFormatter, and helpers must treat both alike —
+// reaching for %v instead silently skipped escaping for the latter.
+func contentString(v interface{}) string {
+	switch s := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return s
+	case fmt.Stringer:
+		return s.String()
+	}
+	return fmt.Sprintf("%v", v)
+}
+
 func templateFuncs() template.FuncMap {
 	return template.FuncMap{
 		"date": func(layout string, t time.Time) string {
@@ -300,13 +315,11 @@ func templateFuncs() template.FuncMap {
 			return fmt.Sprintf("%.1f %s", val, suffix)
 		},
 		"endNewline": func(s interface{}) string {
-			if str, ok := s.(string); ok {
-				if str != "" && !strings.HasSuffix(str, "\n") {
-					return str + "\n"
-				}
-				return str
+			str := contentString(s)
+			if str != "" && !strings.HasSuffix(str, "\n") {
+				return str + "\n"
 			}
-			return fmt.Sprintf("%v", s)
+			return str
 		},
 		"dataURI": func(path string) string {
 			data, err := os.ReadFile(path)
@@ -335,10 +348,7 @@ func templateFuncs() template.FuncMap {
 			return fmt.Sprintf("data:%s;base64,%s", mimeType, b64)
 		},
 		"escape": func(s interface{}) string {
-			if str, ok := s.(string); ok {
-				return html.EscapeString(str)
-			}
-			return fmt.Sprintf("%v", s)
+			return html.EscapeString(contentString(s))
 		},
 		"commafy": func(n interface{}) string {
 			v, ok := asInt64(n)

--- a/pkg/lx/templatex/defaults_test.go
+++ b/pkg/lx/templatex/defaults_test.go
@@ -54,7 +54,7 @@ func TestTemplateFuncs_EndNewline(t *testing.T) {
 		{"hello", "hello\n"},
 		{"already\n", "already\n"},
 		{"", ""},
-		{42, "42"}, // non-string falls back to Sprintf
+		{42, "42\n"}, // every value gets the newline, not just strings
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
`FileContext.Content` is either a `string` or a `LineNumberFormatter`, and the template helpers only handled the former, falling through to `%v` otherwise. So `--html --line-numbers` emitted file content unescaped:

```
--html      →  &lt;script&gt;alert(1)&lt;/script&gt;
--html -l   →  1: <script>alert(1)</script>
```

lx's HTML mode produces a page meant to be opened in a browser, so bundled markup executed when viewed.

Same root cause made per-file `TokenEstimate` fall back to `size/4` under `-l` (1109 → 875 on a 3502-byte file). The `--stats` total was unaffected.

Adds `String()` to `LineNumberFormatter` and routes the helpers through one `contentString` converter.