### PR TITLE
fix: make --follow actually follow directory symlinks

### DIFF
--- a/cmd/lx/testdata/golden/051_symlinks_follow.golden
+++ b/cmd/lx/testdata/golden/051_symlinks_follow.golden
@@ -1,7 +1,11 @@
 --- STDOUT ---
 [1/9] links/broken_link - error: open broken_link: FILE_NOT_FOUND
 
-[2/9] links/cycle_a/to_b - error: is a directory
+[2/9] links/cycle_a/to_b/visible.txt (1 rows)
+---
+```text
+b
+```
 
 [3/9] links/cycle_a/visible.txt (1 rows)
 ---
@@ -9,7 +13,11 @@
 a
 ```
 
-[4/9] links/cycle_b/to_a - error: is a directory
+[4/9] links/cycle_b/to_a/visible.txt (1 rows)
+---
+```text
+a
+```
 
 [5/9] links/cycle_b/visible.txt (1 rows)
 ---
@@ -24,9 +32,17 @@ package main
 func main() {}
 ```
 
-[7/9] links/link_to_pkg - error: is a directory
+[7/9] links/link_to_pkg/util.go (1 rows)
+---
+```go
+package pkg
+```
 
-[8/9] links/loop - error: is a directory
+[8/9] links/loop/recursion.txt (1 rows)
+---
+```text
+I am safe
+```
 
 [9/9] links/safe_target/recursion.txt (1 rows)
 ---

--- a/cmd/lx/testdata/golden/053_symlinks_infinite_cycle.golden
+++ b/cmd/lx/testdata/golden/053_symlinks_infinite_cycle.golden
@@ -1,5 +1,9 @@
 --- STDOUT ---
-[1/2] links/cycle_a/to_b - error: is a directory
+[1/2] links/cycle_a/to_b/visible.txt (1 rows)
+---
+```text
+b
+```
 
 [2/2] links/cycle_a/visible.txt (1 rows)
 ---

--- a/cmd/lx/testdata/golden/056_follow_dirs_no_file_links.golden
+++ b/cmd/lx/testdata/golden/056_follow_dirs_no_file_links.golden
@@ -1,17 +1,41 @@
 --- STDOUT ---
-[1/3] links/cycle_a/visible.txt (1 rows)
----
-```text
-a
-```
-
-[2/3] links/cycle_b/visible.txt (1 rows)
+[1/7] links/cycle_a/to_b/visible.txt (1 rows)
 ---
 ```text
 b
 ```
 
-[3/3] links/safe_target/recursion.txt (1 rows)
+[2/7] links/cycle_a/visible.txt (1 rows)
+---
+```text
+a
+```
+
+[3/7] links/cycle_b/to_a/visible.txt (1 rows)
+---
+```text
+a
+```
+
+[4/7] links/cycle_b/visible.txt (1 rows)
+---
+```text
+b
+```
+
+[5/7] links/link_to_pkg/util.go (1 rows)
+---
+```go
+package pkg
+```
+
+[6/7] links/loop/recursion.txt (1 rows)
+---
+```text
+I am safe
+```
+
+[7/7] links/safe_target/recursion.txt (1 rows)
 ---
 ```text
 I am safe

--- a/cmd/lx/testdata/golden/058_symlinks_follow_include_go.golden
+++ b/cmd/lx/testdata/golden/058_symlinks_follow_include_go.golden
@@ -1,9 +1,15 @@
 --- STDOUT ---
-links/link_to_main.go (~1 rows)
+[1/2] links/link_to_main.go (~1 rows)
 ---
 ```go
 package main
 func main() {}
+```
+
+[2/2] links/link_to_pkg/util.go (1 rows)
+---
+```go
+package pkg
 ```
 
 

--- a/cmd/lx/testdata/golden/059_symlinks_follow_hidden.golden
+++ b/cmd/lx/testdata/golden/059_symlinks_follow_hidden.golden
@@ -7,7 +7,11 @@ i am hidden in links
 
 [2/10] links/broken_link - error: open broken_link: FILE_NOT_FOUND
 
-[3/10] links/cycle_a/to_b - error: is a directory
+[3/10] links/cycle_a/to_b/visible.txt (1 rows)
+---
+```text
+b
+```
 
 [4/10] links/cycle_a/visible.txt (1 rows)
 ---
@@ -15,7 +19,11 @@ i am hidden in links
 a
 ```
 
-[5/10] links/cycle_b/to_a - error: is a directory
+[5/10] links/cycle_b/to_a/visible.txt (1 rows)
+---
+```text
+a
+```
 
 [6/10] links/cycle_b/visible.txt (1 rows)
 ---
@@ -30,9 +38,17 @@ package main
 func main() {}
 ```
 
-[8/10] links/link_to_pkg - error: is a directory
+[8/10] links/link_to_pkg/util.go (1 rows)
+---
+```go
+package pkg
+```
 
-[9/10] links/loop - error: is a directory
+[9/10] links/loop/recursion.txt (1 rows)
+---
+```text
+I am safe
+```
 
 [10/10] links/safe_target/recursion.txt (1 rows)
 ---

--- a/cmd/lx/testdata/golden/091_config_follow.golden
+++ b/cmd/lx/testdata/golden/091_config_follow.golden
@@ -1,7 +1,11 @@
 --- STDOUT ---
 [1/9] links/broken_link - error: open broken_link: FILE_NOT_FOUND
 
-[2/9] links/cycle_a/to_b - error: is a directory
+[2/9] links/cycle_a/to_b/visible.txt (1 rows)
+---
+```text
+b
+```
 
 [3/9] links/cycle_a/visible.txt (1 rows)
 ---
@@ -9,7 +13,11 @@
 a
 ```
 
-[4/9] links/cycle_b/to_a - error: is a directory
+[4/9] links/cycle_b/to_a/visible.txt (1 rows)
+---
+```text
+a
+```
 
 [5/9] links/cycle_b/visible.txt (1 rows)
 ---
@@ -26,7 +34,11 @@ func main() {}
 
 [7/9] links/link_to_pkg - error: open link_to_pkg: FILE_NOT_FOUND
 
-[8/9] links/loop - error: is a directory
+[8/9] links/loop/recursion.txt (1 rows)
+---
+```text
+I am safe
+```
 
 [9/9] links/safe_target/recursion.txt (1 rows)
 ---

--- a/cmd/lx/testdata/golden/092_config_combined.golden
+++ b/cmd/lx/testdata/golden/092_config_combined.golden
@@ -7,7 +7,11 @@ i am hidden in links
 
 [2/10] links/broken_link - error: open broken_link: FILE_NOT_FOUND
 
-[3/10] links/cycle_a/to_b - error: is a directory
+[3/10] links/cycle_a/to_b/visible.txt (1 rows)
+---
+```text
+b
+```
 
 [4/10] links/cycle_a/visible.txt (1 rows)
 ---
@@ -15,7 +19,11 @@ i am hidden in links
 a
 ```
 
-[5/10] links/cycle_b/to_a - error: is a directory
+[5/10] links/cycle_b/to_a/visible.txt (1 rows)
+---
+```text
+a
+```
 
 [6/10] links/cycle_b/visible.txt (1 rows)
 ---
@@ -32,7 +40,11 @@ func main() {}
 
 [8/10] links/link_to_pkg - error: open link_to_pkg: FILE_NOT_FOUND
 
-[9/10] links/loop - error: is a directory
+[9/10] links/loop/recursion.txt (1 rows)
+---
+```text
+I am safe
+```
 
 [10/10] links/safe_target/recursion.txt (1 rows)
 ---

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -338,6 +338,8 @@ func processStream(ctx context.Context, parsed *ParsedArgs, rawArgs []string) er
 				walker := lx.NewWalker(baseRules, overrideRules)
 				walker.IgnoreEnabled = !section.RunCfg.NoIgnore
 				walker.SkipHidden = !section.RunCfg.ShowHidden && !isForced
+				walker.FollowDirSymlinks = section.RunCfg.FollowDirSymlinks
+				walker.SkipFileSymlinks = section.RunCfg.SkipFileSymlinks
 				if debugLoggingEnabled {
 					walker.OnIgnore = func(p, reason string) {
 						slog.Debug("Ignored", "path", p, "reason", reason)
@@ -370,19 +372,6 @@ func processStream(ctx context.Context, parsed *ParsedArgs, rawArgs []string) er
 							effectivePath = displayPrefix
 						} else {
 							effectivePath = filepath.Join(displayPrefix, filepath.FromSlash(path))
-						}
-					}
-
-					if (d.Type() & fs.ModeSymlink) != 0 {
-						if section.RunCfg.SkipFileSymlinks {
-							return nil
-						}
-						targetInfo, err := fs.Stat(fsys, path)
-						if err == nil && targetInfo.IsDir() {
-							if !section.RunCfg.FollowDirSymlinks {
-								slog.Debug("Skipping directory symlink", "path", effectivePath)
-								return nil
-							}
 						}
 					}
 

--- a/internal/cli/tree.go
+++ b/internal/cli/tree.go
@@ -158,6 +158,8 @@ func collectTreePaths(ctx context.Context, op Op, runCfg lx.RunnerConfig, includ
 	w := lx.NewWalker(baseRules, overrideRules)
 	w.IgnoreEnabled = !runCfg.NoIgnore
 	w.SkipHidden = !runCfg.ShowHidden && !isForced
+	w.FollowDirSymlinks = runCfg.FollowDirSymlinks
+	w.SkipFileSymlinks = runCfg.SkipFileSymlinks
 
 	_ = w.Walk(fsys, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {

--- a/pkg/lx/walker/types.go
+++ b/pkg/lx/walker/types.go
@@ -17,7 +17,12 @@ type Walker struct {
 	OverrideRules []Rule
 	IgnoreEnabled bool
 	SkipHidden    bool
-	OnIgnore      func(path string, reason string)
+
+	// FollowDirSymlinks descends into symlinks that resolve to directories.
+	// SkipFileSymlinks drops symlinks that resolve to files.
+	FollowDirSymlinks bool
+	SkipFileSymlinks  bool
+	OnIgnore          func(path string, reason string)
 }
 
 // NewWalker initializes the walker.

--- a/pkg/lx/walker/walk.go
+++ b/pkg/lx/walker/walk.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"io/fs"
+	"os"
 	"path"
 	"strings"
 )
@@ -59,10 +60,46 @@ func (w *Walker) Walk(fsys fs.FS, root string, walkFn fs.WalkDirFunc) error {
 
 	initialRules := make([]Rule, 0, len(w.BaseRules))
 	initialRules = append(initialRules, w.BaseRules...)
-	return w.recursiveWalk(fsys, root, initialRules, walkFn, false)
+	return w.recursiveWalk(fsys, root, initialRules, walkFn, false, []fs.FileInfo{info})
 }
 
-func (w *Walker) recursiveWalk(fsys fs.FS, dir string, parentRules []Rule, walkFn fs.WalkDirFunc, parentIgnored bool) error {
+// resolveEntry reports how an entry should be treated, applying symlink policy.
+// A symlink whose target cannot be stat'd is left as a file so the callback can
+// surface the error.
+func (w *Walker) resolveEntry(fsys fs.FS, path string, d fs.DirEntry, ancestors []fs.FileInfo) (isDir bool, target fs.FileInfo, skip bool, reason string) {
+	if d.Type()&fs.ModeSymlink == 0 {
+		return d.IsDir(), nil, false, ""
+	}
+
+	info, err := fs.Stat(fsys, path)
+	if err != nil {
+		// Broken link. It resolves to nothing, so file-symlink policy governs
+		// it; otherwise leave it for the callback to report.
+		if w.SkipFileSymlinks {
+			return false, nil, true, "file symlink"
+		}
+		return false, nil, false, ""
+	}
+
+	if !info.IsDir() {
+		if w.SkipFileSymlinks {
+			return false, nil, true, "file symlink"
+		}
+		return false, nil, false, ""
+	}
+
+	if !w.FollowDirSymlinks {
+		return false, nil, true, "directory symlink"
+	}
+	for _, a := range ancestors {
+		if os.SameFile(a, info) {
+			return true, info, true, "symlink cycle"
+		}
+	}
+	return true, info, false, ""
+}
+
+func (w *Walker) recursiveWalk(fsys fs.FS, dir string, parentRules []Rule, walkFn fs.WalkDirFunc, parentIgnored bool, ancestors []fs.FileInfo) error {
 	var localRules []Rule
 	if w.IgnoreEnabled {
 		localRules = w.loadIgnoreFiles(fsys, dir)
@@ -104,12 +141,34 @@ func (w *Walker) recursiveWalk(fsys fs.FS, dir string, parentRules []Rule, walkF
 			continue
 		}
 
-		isIgnored, reason := checkIgnore(childPath, d.IsDir(), effectiveRules, parentIgnored, w.OnIgnore != nil)
+		isDir, target, skip, skipReason := w.resolveEntry(fsys, childPath, d, ancestors)
+		if skip {
+			if w.OnIgnore != nil {
+				w.OnIgnore(childPath, skipReason)
+			}
+			continue
+		}
 
-		if d.IsDir() {
+		// Cycle detection needs every directory on the current path, not just
+		// the followed links. Skipped entirely when not following, so ordinary
+		// walks pay no extra stat.
+		childAncestors := ancestors
+		if isDir && w.FollowDirSymlinks {
+			info := target
+			if info == nil {
+				info, _ = d.Info()
+			}
+			if info != nil {
+				childAncestors = append(ancestors, info)
+			}
+		}
+
+		isIgnored, reason := checkIgnore(childPath, isDir, effectiveRules, parentIgnored, w.OnIgnore != nil)
+
+		if isDir {
 			if isIgnored {
 				if hasNestedException(childPath, effectiveRules) {
-					if err := w.recursiveWalk(fsys, childPath, mergedRules, walkFn, true); err != nil {
+					if err := w.recursiveWalk(fsys, childPath, mergedRules, walkFn, true, childAncestors); err != nil {
 						return err
 					}
 					continue
@@ -120,14 +179,18 @@ func (w *Walker) recursiveWalk(fsys fs.FS, dir string, parentRules []Rule, walkF
 				continue
 			}
 
-			if err := walkFn(childPath, d, nil); err != nil {
+			entry := d
+			if target != nil {
+				entry = followedDirEntry{DirEntry: d, info: target}
+			}
+			if err := walkFn(childPath, entry, nil); err != nil {
 				if err == fs.SkipDir {
 					continue
 				}
 				return err
 			}
 
-			if err := w.recursiveWalk(fsys, childPath, mergedRules, walkFn, false); err != nil {
+			if err := w.recursiveWalk(fsys, childPath, mergedRules, walkFn, false, childAncestors); err != nil {
 				return err
 			}
 			continue
@@ -172,6 +235,18 @@ func (w *Walker) loadIgnoreFiles(fsys fs.FS, dir string) []Rule {
 	}
 	return rules
 }
+
+// followedDirEntry presents a followed directory symlink as a directory, so
+// callbacks branch on it the same way they branch on a real one. The embedded
+// entry keeps the link's own name.
+type followedDirEntry struct {
+	fs.DirEntry
+	info fs.FileInfo
+}
+
+func (f followedDirEntry) IsDir() bool                { return true }
+func (f followedDirEntry) Type() fs.FileMode          { return fs.ModeDir }
+func (f followedDirEntry) Info() (fs.FileInfo, error) { return f.info, nil }
 
 type dirEntryAdapter struct {
 	info fs.FileInfo

--- a/pkg/lx/walker/walk_test.go
+++ b/pkg/lx/walker/walk_test.go
@@ -4,8 +4,11 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestWalker_NestedIgnores(t *testing.T) {
@@ -427,4 +430,110 @@ func TestWalker_IgnoreDisabled(t *testing.T) {
 
 	files := collectPaths(t, w, tmp)
 	assertContains(t, files, "keep.log")
+}
+
+func symlinkTree(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	mustMkdir := func(p string) {
+		if err := os.MkdirAll(filepath.Join(dir, p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite := func(p, content string) {
+		if err := os.WriteFile(filepath.Join(dir, p), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustLink := func(target, name string) {
+		if err := os.Symlink(target, filepath.Join(dir, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mustMkdir("real")
+	mustWrite("real/inside.txt", "x")
+	mustWrite("top.txt", "y")
+	mustLink("real", "dirlink")
+	mustLink("top.txt", "filelink")
+	mustLink("nowhere", "brokenlink")
+	return dir
+}
+
+func walkPaths(t *testing.T, dir string, configure func(*Walker)) []string {
+	t.Helper()
+	w := NewWalker(nil, nil)
+	if configure != nil {
+		configure(w)
+	}
+	var got []string
+	err := w.Walk(os.DirFS(dir), ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		got = append(got, p)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Walk failed: %v", err)
+	}
+	sort.Strings(got)
+	return got
+}
+
+func TestWalkSkipsDirectorySymlinksByDefault(t *testing.T) {
+	got := walkPaths(t, symlinkTree(t), nil)
+	want := []string{"brokenlink", "filelink", "real/inside.txt", "top.txt"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestWalkFollowsDirectorySymlinksWhenEnabled(t *testing.T) {
+	got := walkPaths(t, symlinkTree(t), func(w *Walker) { w.FollowDirSymlinks = true })
+	want := []string{"brokenlink", "dirlink/inside.txt", "filelink", "real/inside.txt", "top.txt"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// A broken link resolves to nothing, so file-symlink policy governs it.
+func TestWalkSkipFileSymlinksDropsFileAndBrokenLinks(t *testing.T) {
+	got := walkPaths(t, symlinkTree(t), func(w *Walker) { w.SkipFileSymlinks = true })
+	want := []string{"real/inside.txt", "top.txt"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestWalkFollowTerminatesOnSymlinkCycle(t *testing.T) {
+	dir := t.TempDir()
+	for _, d := range []string{"a", "b"} {
+		if err := os.MkdirAll(filepath.Join(dir, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, d, "f.txt"), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink("../b", filepath.Join(dir, "a", "to_b")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../a", filepath.Join(dir, "b", "to_a")); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan []string, 1)
+	go func() { done <- walkPaths(t, dir, func(w *Walker) { w.FollowDirSymlinks = true }) }()
+
+	select {
+	case got := <-done:
+		for _, p := range got {
+			if strings.Count(p, "to_") > 1 {
+				t.Errorf("walk recursed through the cycle repeatedly: %q", p)
+			}
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("walk did not terminate on a symlink cycle")
+	}
 }


### PR DESCRIPTION
`recursiveWalk` branched on `d.IsDir()`, which is false for a symlink-to-directory, so the entry reached the file branch and the CLI callback — which has no way to tell the walker to descend. `--follow` therefore never followed, and emitted a bogus row:

```
$ lx --follow dir/
[1/2] dir/link - error: is a directory
```

Moves symlink policy into `Walker` (`FollowDirSymlinks`, `SkipFileSymlinks`) where recursion lives, with ancestor-based cycle detection. The tree pass gets the same policy, which it previously lacked entirely — so `-t` and content output now agree under `--no-links`.

7 golden files updated, each replacing an `error: is a directory` row with the followed content.