### PR TITLE
fix: embed images from source bytes in html output

### DIFF
--- a/cmd/lx/golden_core_test.go
+++ b/cmd/lx/golden_core_test.go
@@ -189,6 +189,7 @@ func TestGoldenArchive(t *testing.T) {
 		{name: "117_expand_archive_hidden_filter_go", args: []string{"-Z", "-H", "-i", "*.go", "archive.zip"}},
 		{name: "118_expand_archive_tar_bz2", args: []string{"-Z", "archive.tar.bz2"}},
 		{name: "119_expand_archive_tar", args: []string{"-Z", "archive.tar"}},
+		{name: "119b_archive_image_html", args: []string{"--html", "-Z", "images.zip"}},
 	})
 }
 

--- a/cmd/lx/goldenfixtures/archive.go
+++ b/cmd/lx/goldenfixtures/archive.go
@@ -29,6 +29,10 @@ func SetupArchiveFixture(t *testing.T) string {
 		{"hello.txt", "Hello from tar bz2!\n"},
 		{"nested/world.go", "package nested\n"},
 	})
+	createTestZip(filepath.Join(dir, "images.zip"), [][2]string{
+		{"logo.png", "\x89PNG\r\n\x1a\n\x00\x00\x00\x0D"},
+		{"notes.txt", "beside the image\n"},
+	})
 	createTestTar(filepath.Join(dir, "archive.tar"), [][2]string{
 		{"hello.txt", "Hello from tar plain!\n"},
 		{"nested/world.go", "package nested\n"},

--- a/cmd/lx/testdata/golden/119b_archive_image_html.golden
+++ b/cmd/lx/testdata/golden/119b_archive_image_html.golden
@@ -1,0 +1,70 @@
+--- STDOUT ---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>lx Output</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.classless.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" media="(prefers-color-scheme: light)">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" media="(prefers-color-scheme: dark)">
+<style>
+.hljs { background: transparent !important; }
+img { max-width: 100%; height: auto; }
+pre { background-color: transparent; border: none; }
+article > header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background-color: var(--pico-card-background-color); 
+  border-bottom: 1px solid var(--pico-muted-border-color);
+}
+.file-anchor {
+  text-decoration: none;
+  color: var(--pico-muted-color);
+  margin-right: 0.5rem;
+  font-weight: bold;
+  border: none;
+}
+.file-anchor:hover {
+  color: var(--pico-primary);
+  text-decoration: underline;
+}
+.error-state { color: var(--pico-color-red-500); font-weight: bold; }
+</style>
+</head>
+<body>
+<header>
+<hgroup>
+<h1>lx output</h1>
+<p>
+  Files: 2 &bull; 
+  Size: 29 B &bull; 
+  Path: .
+</p>
+</hgroup>
+</header>
+<main>
+<article id="file-1">
+<header>
+ <a href="#file-1" aria-label="Link to this file"><strong>images.zip/logo.png</strong></a>
+</header>
+<img src="data:image/png;base64,iVBORw0KGgoAAAAN" alt="images.zip/logo.png" />
+</article>
+<article id="file-2">
+<header>
+ <a href="#file-2" aria-label="Link to this file"><strong>images.zip/notes.txt</strong></a>
+ <small>(1 rows)</small>
+</header>
+<pre><code class="language-text">
+beside the image
+</code></pre>
+</article>
+</section></main>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+<script>hljs.highlightAll();</script>
+</body>
+</html>
+
+--- STDERR ---

--- a/pkg/lx/core/types.go
+++ b/pkg/lx/core/types.go
@@ -96,6 +96,7 @@ type FileContext struct {
 	Content          interface{}
 	IsBinary         bool
 	IsImage          bool
+	DataURI          string
 	IsCompactView    bool
 	FileIndex        int
 	SectionFileIndex int

--- a/pkg/lx/internal/image.go
+++ b/pkg/lx/internal/image.go
@@ -1,6 +1,9 @@
 package internal
 
 import (
+	"encoding/base64"
+	"fmt"
+	"mime"
 	"path"
 	"strings"
 )
@@ -20,4 +23,32 @@ var imageExtensions = map[string]bool{
 func IsImage(p string) bool {
 	ext := strings.ToLower(path.Ext(p))
 	return imageExtensions[ext]
+}
+
+// MIMEType guesses a content type from the path's extension, covering the
+// image types the system table commonly omits.
+func MIMEType(p string) string {
+	ext := strings.ToLower(path.Ext(p))
+	if t := mime.TypeByExtension(ext); t != "" {
+		return t
+	}
+	switch ext {
+	case ".svg":
+		return "image/svg+xml"
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".png":
+		return "image/png"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	}
+	return "application/octet-stream"
+}
+
+// DataURI encodes already-read bytes. Callers pass content from the source that
+// produced the file, so archive entries and URLs work the same as local paths.
+func DataURI(p string, data []byte) string {
+	return fmt.Sprintf("data:%s;base64,%s", MIMEType(p), base64.StdEncoding.EncodeToString(data))
 }

--- a/pkg/lx/internal/image_test.go
+++ b/pkg/lx/internal/image_test.go
@@ -25,3 +25,25 @@ func TestIsImage(t *testing.T) {
 		})
 	}
 }
+
+func TestMIMEType(t *testing.T) {
+	cases := map[string]string{
+		"a/logo.PNG":  "image/png",
+		"photo.jpeg":  "image/jpeg",
+		"icon.svg":    "image/svg+xml",
+		"archive.bin": "application/octet-stream",
+	}
+	for path, want := range cases {
+		if got := MIMEType(path); got != want {
+			t.Errorf("MIMEType(%q) = %q, want %q", path, got, want)
+		}
+	}
+}
+
+func TestDataURIEncodesGivenBytes(t *testing.T) {
+	got := DataURI("logo.png", []byte("hi"))
+	want := "data:image/png;base64,aGk="
+	if got != want {
+		t.Errorf("DataURI = %q, want %q", got, want)
+	}
+}

--- a/pkg/lx/render/processor.go
+++ b/pkg/lx/render/processor.go
@@ -259,6 +259,17 @@ func (p *Processor) prepareFileContext(file sources.InputFile, index int, scratc
 		}
 	}
 
+	// Encode images from the bytes already open here. Reading them back by
+	// path in a template would fail for archive entries and URLs, which have
+	// no readable AbsPath.
+	var dataURI string
+	if isImage && p.format == "html" && size > 0 {
+		data := make([]byte, size)
+		if _, err := reader.ReadAt(data, 0); err == nil {
+			dataURI = internal.DataURI(file.Path, data)
+		}
+	}
+
 	isCompact := (cfg.Head == 0 && cfg.Tail == 0) || isBinary || size == 0
 	totalRows, exact, _ := internal.EstimateLineCount(reader, size, scratch)
 
@@ -296,6 +307,7 @@ func (p *Processor) prepareFileContext(file sources.InputFile, index int, scratc
 		TokenEstimate: p.tokenCounter(size, contentData),
 		IsBinary:      isBinary,
 		IsImage:       isImage,
+		DataURI:       dataURI,
 		IsCompactView: isCompact,
 		FileIndex:     index,
 		Global:        p.global,

--- a/pkg/lx/templatex/defaults.go
+++ b/pkg/lx/templatex/defaults.go
@@ -1,16 +1,15 @@
 package templatex
 
 import (
-	"encoding/base64"
 	"fmt"
 	"html"
 	"math"
-	"mime"
 	"os"
-	"path/filepath"
 	"strings"
 	"text/template"
 	"time"
+
+	"github.com/rasros/lx/pkg/lx/internal"
 )
 
 type formatDefaults struct {
@@ -203,7 +202,7 @@ const defaultHTMLContent = `<article id="file-{{ .FileIndex }}">
 {{- end }}
 </header>
 {{- if .IsImage }}
-<img src="{{ .AbsPath | dataURI }}" alt="{{ .Path }}" />
+<img src="{{ .DataURI }}" alt="{{ .Path }}" />
 {{- else }}
 <pre><code{{ if .Language }} class="language-{{ .Language }}"{{ end }}>
 {{ .Content | escape | endNewline }}</code></pre>
@@ -313,26 +312,7 @@ func templateFuncs() template.FuncMap {
 			if err != nil {
 				return ""
 			}
-			ext := strings.ToLower(filepath.Ext(path))
-			mimeType := mime.TypeByExtension(ext)
-			if mimeType == "" {
-				switch ext {
-				case ".svg":
-					mimeType = "image/svg+xml"
-				case ".jpg", ".jpeg":
-					mimeType = "image/jpeg"
-				case ".png":
-					mimeType = "image/png"
-				case ".gif":
-					mimeType = "image/gif"
-				case ".webp":
-					mimeType = "image/webp"
-				default:
-					mimeType = "application/octet-stream"
-				}
-			}
-			b64 := base64.StdEncoding.EncodeToString(data)
-			return fmt.Sprintf("data:%s;base64,%s", mimeType, b64)
+			return internal.DataURI(path, data)
 		},
 		"escape": func(s interface{}) string {
 			if str, ok := s.(string); ok {


### PR DESCRIPTION
The `dataURI` template helper did `os.ReadFile(AbsPath)`, but archive entries, URLs and buffers have no readable path there — so `--html` over an archive emitted `<img src="">` with no warning.

The processor already has the bytes open, so it now encodes the image there and exposes `FileContext.DataURI`. The `dataURI` helper stays for custom templates that pass a real path, and both share one implementation in `internal`.

Verified: an image inside a zip now embeds byte-identically to the same file on disk.