### PR TITLE
refactor: reshape the render path for upcoming converters

### DIFF
--- a/pkg/lx/core/types.go
+++ b/pkg/lx/core/types.go
@@ -43,6 +43,7 @@ type TemplateEngine struct {
 	FileError   *template.Template
 	FileBinary  *template.Template
 	FileCompact *template.Template
+	FileImage   *template.Template
 
 	Section *template.Template
 	Prompt  *template.Template
@@ -55,6 +56,11 @@ type TemplateEngine struct {
 	OutputHeader *template.Template
 	OutputFooter *template.Template
 	Stats        *template.Template
+
+	// Policy the output format implies, resolved once at compile time so
+	// renderers do not branch on the format name.
+	EmbedImages   bool
+	UseSeparators bool
 }
 
 // Config represents the core library configuration.

--- a/pkg/lx/render/processor.go
+++ b/pkg/lx/render/processor.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,15 +30,19 @@ type PreparedItem struct {
 
 // Processor renders prepared items into an output writer.
 type Processor struct {
-	engine         *core.TemplateEngine
-	global         core.GlobalContext
-	tokenCounter   core.TokenCounter
-	onFileError    FileErrorHandler
-	lastWasCompact bool
-	lastWasBinary  bool
-	lastWasError   bool
-	lastRows       int
-	format         string
+	engine       *core.TemplateEngine
+	global       core.GlobalContext
+	tokenCounter core.TokenCounter
+	onFileError  FileErrorHandler
+}
+
+// RenderStats reports what one rendered item turned out to be. A non-file item
+// yields the zero value.
+type RenderStats struct {
+	Rows      int
+	IsCompact bool
+	IsBinary  bool
+	IsError   bool
 }
 
 type readerAtWithSize interface {
@@ -49,13 +54,12 @@ type byteReaderProvider interface {
 	ByteReader() *bytes.Reader
 }
 
-func NewProcessor(engine *core.TemplateEngine, global core.GlobalContext, onError FileErrorHandler, format string) *Processor {
+func NewProcessor(engine *core.TemplateEngine, global core.GlobalContext, onError FileErrorHandler) *Processor {
 	return &Processor{
 		engine:       engine,
 		global:       global,
 		onFileError:  onError,
 		tokenCounter: core.DefaultTokenCounter,
-		format:       format,
 	}
 }
 
@@ -65,48 +69,33 @@ func (p *Processor) SetTokenCounter(tc core.TokenCounter) {
 	}
 }
 
-func (p *Processor) LastWasCompact() bool { return p.lastWasCompact }
-
-func (p *Processor) LastRows() int { return p.lastRows }
-
-func (p *Processor) LastWasBinary() bool { return p.lastWasBinary }
-
-func (p *Processor) LastWasError() bool { return p.lastWasError }
-
 // RenderPrepared processes one item containing pre-calculated section and indices.
-func (p *Processor) RenderPrepared(w io.Writer, item PreparedItem, scratchBuf []byte) error {
-	var isCompact bool
-	var err error
+func (p *Processor) RenderPrepared(w io.Writer, item PreparedItem, scratchBuf []byte) (RenderStats, error) {
+	var stats RenderStats
 	var ctx interface{}
 	var templateToUse *template.Template
 
-	p.lastRows = 0
-	p.lastWasBinary = false
-	p.lastWasError = false
 	switch v := item.Raw.(type) {
 	case sources.InputFile:
-		var fCtx core.FileContext
-		fCtx, err = p.prepareFileContext(v, item.FileIndexGlobal, scratchBuf)
+		fCtx, err := p.prepareFileContext(v, item.FileIndexGlobal, scratchBuf)
 		if err != nil {
-			return err
+			return stats, err
 		}
 		fCtx.Section = *item.Section
 		fCtx.SectionFileIndex = item.FileIndexSection
 
-		isCompact = fCtx.IsCompactView
-		p.lastRows = fCtx.TotalRows
-		p.lastWasBinary = fCtx.IsBinary
-		p.lastWasError = fCtx.IsError
+		stats = RenderStats{
+			Rows:      fCtx.TotalRows,
+			IsCompact: fCtx.IsCompactView,
+			IsBinary:  fCtx.IsBinary,
+			IsError:   fCtx.IsError,
+		}
 		ctx = &fCtx
 
 		if fCtx.IsError {
 			templateToUse = p.engine.FileError
 		} else if fCtx.IsImage {
-			if p.format == "html" {
-				templateToUse = p.engine.FileContent
-			} else {
-				templateToUse = p.engine.FileBinary
-			}
+			templateToUse = p.engine.FileImage
 		} else if fCtx.IsBinary {
 			templateToUse = p.engine.FileBinary
 		} else if fCtx.IsCompactView {
@@ -139,15 +128,13 @@ func (p *Processor) RenderPrepared(w io.Writer, item PreparedItem, scratchBuf []
 		templateToUse = p.engine.Meta
 
 	default:
-		return nil
+		return stats, nil
 	}
 
 	if err := templateToUse.Execute(w, ctx); err != nil {
-		return err
+		return stats, err
 	}
-
-	p.lastWasCompact = isCompact
-	return nil
+	return stats, nil
 }
 
 // errorContext describes a file that could not be read.
@@ -184,18 +171,85 @@ func readerFor(rc io.ReadCloser, sizeHint int64) (io.ReaderAt, int64) {
 	return bytes.NewReader(data), int64(len(data))
 }
 
-// convert replaces file content with a text rendering of it when a converter
-// applies, and reports the format converted from. A converter that fails leaves
-// the content untouched.
-func convert(file sources.InputFile, reader io.ReaderAt, size int64) (io.ReaderAt, int64, string) {
-	if file.Config.ExtractDocuments && sources.IsDocumentPath(file.Path) {
-		text, err := sources.ExtractDocumentText(file.Path, reader, size)
+// converter replaces a file's bytes with a text rendering of them. Converters
+// run before binary and language detection, so detection describes what will
+// actually be rendered, and they select on the path rather than the content, so
+// choosing one needs no detection. Order matters only if two ever match the
+// same path; the first match wins.
+type converter struct {
+	name    string
+	applies func(sources.InputFile) bool
+	convert func(path string, r io.ReaderAt, size int64) ([]byte, error)
+}
+
+var converters = []converter{
+	{
+		name: "document",
+		applies: func(f sources.InputFile) bool {
+			return f.Config.ExtractDocuments && sources.IsDocumentPath(f.Path)
+		},
+		convert: sources.ExtractDocumentText,
+	},
+}
+
+// applyConverters reports the format it converted from, or "" if none applied.
+// A converter that fails leaves the content untouched.
+func applyConverters(file sources.InputFile, reader io.ReaderAt, size int64) (io.ReaderAt, int64, string) {
+	for _, c := range converters {
+		if !c.applies(file) {
+			continue
+		}
+		text, err := c.convert(file.Path, reader, size)
 		if err != nil {
+			slog.Debug("Converter failed, keeping raw content",
+				"converter", c.name, "path", file.Path, "error", err)
 			return reader, size, ""
 		}
 		return bytes.NewReader(text), int64(len(text)), fileFormat(file.Path)
 	}
 	return reader, size, ""
+}
+
+// detectContent sniffs the header for binary content and a language hint.
+func detectContent(path string, reader io.ReaderAt, scratch []byte) (isBinary bool, lang string) {
+	headerLen := len(scratch)
+	if headerLen > 1024 {
+		headerLen = 1024
+	}
+	n, _ := reader.ReadAt(scratch[:headerLen], 0)
+	return internal.IsBinary(scratch[:n]), internal.DetectLanguage(path, scratch[:n])
+}
+
+// applySkeleton reduces source to signatures and definitions. Unlike a
+// converter it runs after detection, because it needs the detected language. It
+// also reports the pre-filter row count, so headers can describe the whole file.
+func applySkeleton(cfg core.RunnerConfig, lang string, reader io.ReaderAt, size int64, isBinary, isImage bool) (io.ReaderAt, int64, string, int) {
+	if isBinary || isImage || (!cfg.SkeletonFunctions && !cfg.SkeletonTypes) || !skeleton.Supported(lang) {
+		return reader, size, "", -1
+	}
+
+	allData := make([]byte, size)
+	if _, err := reader.ReadAt(allData, 0); err != nil {
+		return reader, size, "", -1
+	}
+
+	filtered := skeleton.Extract(lang, allData, cfg.SkeletonFunctions, cfg.SkeletonTypes)
+	return bytes.NewReader(filtered), int64(len(filtered)),
+		skeletonModeLabel(cfg.SkeletonFunctions, cfg.SkeletonTypes), internal.CountLines(allData)
+}
+
+// imageDataURI encodes the image from the bytes already open here. Reading them
+// back by path in a template would fail for archive entries and URLs, which
+// have no readable AbsPath.
+func imageDataURI(path string, reader io.ReaderAt, size int64) string {
+	if size <= 0 {
+		return ""
+	}
+	data := make([]byte, size)
+	if _, err := reader.ReadAt(data, 0); err != nil {
+		return ""
+	}
+	return internal.DataURI(path, data)
 }
 
 func fileFormat(path string) string {
@@ -230,44 +284,21 @@ func (p *Processor) prepareFileContext(file sources.InputFile, index int, scratc
 	}
 
 	reader, size := readerFor(rc, file.Size)
-	reader, size, convertedFrom := convert(file, reader, size)
+	reader, size, convertedFrom := applyConverters(file, reader, size)
 
 	if scratch == nil {
 		scratch = make([]byte, 1024)
 	}
-	headerLen := 1024
-	if len(scratch) < headerLen {
-		headerLen = len(scratch)
-	}
 
-	n, _ := reader.ReadAt(scratch[:headerLen], 0)
-	isBinary := internal.IsBinary(scratch[:n])
-	lang := internal.DetectLanguage(file.Path, scratch[:n])
+	isBinary, lang := detectContent(file.Path, reader, scratch)
 	isImage := internal.IsImage(file.Path)
 	cfg := file.Config
 
-	var skeletonMode string
-	originalRows := -1
-	if !isBinary && !isImage && (cfg.SkeletonFunctions || cfg.SkeletonTypes) && skeleton.Supported(lang) {
-		allData := make([]byte, size)
-		if _, err := reader.ReadAt(allData, 0); err == nil {
-			originalRows = internal.CountLines(allData)
-			filtered := skeleton.Extract(lang, allData, cfg.SkeletonFunctions, cfg.SkeletonTypes)
-			reader = bytes.NewReader(filtered)
-			size = int64(len(filtered))
-			skeletonMode = skeletonModeLabel(cfg.SkeletonFunctions, cfg.SkeletonTypes)
-		}
-	}
+	reader, size, skeletonMode, originalRows := applySkeleton(cfg, lang, reader, size, isBinary, isImage)
 
-	// Encode images from the bytes already open here. Reading them back by
-	// path in a template would fail for archive entries and URLs, which have
-	// no readable AbsPath.
 	var dataURI string
-	if isImage && p.format == "html" && size > 0 {
-		data := make([]byte, size)
-		if _, err := reader.ReadAt(data, 0); err == nil {
-			dataURI = internal.DataURI(file.Path, data)
-		}
+	if isImage && p.engine.EmbedImages {
+		dataURI = imageDataURI(file.Path, reader, size)
 	}
 
 	isCompact := (cfg.Head == 0 && cfg.Tail == 0) || isBinary || size == 0

--- a/pkg/lx/render/processor_test.go
+++ b/pkg/lx/render/processor_test.go
@@ -18,7 +18,7 @@ func TestProcessor_RenderFile_Slicing(t *testing.T) {
 	engine, _ := templatex.Compile(cfg)
 	global := core.GlobalContext{TotalFiles: 1}
 
-	proc := NewProcessor(engine, global, nil, "markdown")
+	proc := NewProcessor(engine, global, nil)
 
 	file := sources.NewBufferInputFile("slice.txt", []byte("1\n2\n3\n4\n5\n"))
 	file.Config = core.RunnerConfig{Head: 1, Tail: 1}
@@ -27,7 +27,7 @@ func TestProcessor_RenderFile_Slicing(t *testing.T) {
 	item := PreparedItem{Raw: file, Section: &core.SectionContext{}, FileIndexGlobal: 1}
 
 	var buf bytes.Buffer
-	if err := proc.RenderPrepared(&buf, item, scratch); err != nil {
+	if _, err := proc.RenderPrepared(&buf, item, scratch); err != nil {
 		t.Fatal(err)
 	}
 
@@ -45,7 +45,7 @@ func TestProcessor_RenderFile_SkeletonSlicingUsesFilteredRows(t *testing.T) {
 	engine, _ := templatex.Compile(cfg)
 	global := core.GlobalContext{TotalFiles: 1}
 
-	proc := NewProcessor(engine, global, nil, "markdown")
+	proc := NewProcessor(engine, global, nil)
 
 	file := sources.NewBufferInputFile("skeleton.go", []byte(`package p
 
@@ -66,7 +66,7 @@ func C() {
 	item := PreparedItem{Raw: file, Section: &core.SectionContext{}, FileIndexGlobal: 1}
 
 	var buf bytes.Buffer
-	if err := proc.RenderPrepared(&buf, item, nil); err != nil {
+	if _, err := proc.RenderPrepared(&buf, item, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -92,7 +92,7 @@ func TestRender_DataURI(t *testing.T) {
 	cfg.OutputFormat = "html"
 	engine, _ := templatex.Compile(cfg)
 
-	proc := NewProcessor(engine, core.GlobalContext{}, nil, "html")
+	proc := NewProcessor(engine, core.GlobalContext{}, nil)
 
 	file, err := sources.NewInputFileFromPath(os.DirFS(tmp), imgName)
 	if err != nil {
@@ -103,7 +103,7 @@ func TestRender_DataURI(t *testing.T) {
 	item := PreparedItem{Raw: file, Section: &core.SectionContext{}, FileIndexGlobal: 1}
 
 	var buf bytes.Buffer
-	if err := proc.RenderPrepared(&buf, item, nil); err != nil {
+	if _, err := proc.RenderPrepared(&buf, item, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -117,13 +117,13 @@ func TestRender_ErrorHandling(t *testing.T) {
 	cfg := core.NewConfig()
 	engine, _ := templatex.Compile(cfg)
 
-	proc := NewProcessor(engine, core.GlobalContext{}, nil, "markdown")
+	proc := NewProcessor(engine, core.GlobalContext{}, nil)
 
 	file := sources.InputFile{Path: "ghost.txt", Open: func() (io.ReadCloser, error) { return nil, os.ErrPermission }}
 	item := PreparedItem{Raw: file, Section: &core.SectionContext{}}
 
 	var buf bytes.Buffer
-	if err := proc.RenderPrepared(&buf, item, nil); err != nil {
+	if _, err := proc.RenderPrepared(&buf, item, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -136,7 +136,7 @@ func TestRender_ErrorHandling(t *testing.T) {
 func TestRender_BinaryFile(t *testing.T) {
 	cfg := core.NewConfig()
 	engine, _ := templatex.Compile(cfg)
-	proc := NewProcessor(engine, core.GlobalContext{}, nil, "markdown")
+	proc := NewProcessor(engine, core.GlobalContext{}, nil)
 
 	binaryContent := append([]byte("ELF"), 0x00, 0x01, 0x02, 0x03)
 	file := sources.NewBufferInputFile("program", binaryContent)
@@ -145,7 +145,7 @@ func TestRender_BinaryFile(t *testing.T) {
 	item := PreparedItem{Raw: file, Section: &core.SectionContext{}, FileIndexGlobal: 1}
 
 	var buf bytes.Buffer
-	if err := proc.RenderPrepared(&buf, item, nil); err != nil {
+	if _, err := proc.RenderPrepared(&buf, item, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -158,7 +158,7 @@ func TestRender_BinaryFile(t *testing.T) {
 func TestRender_CompactView(t *testing.T) {
 	cfg := core.NewConfig()
 	engine, _ := templatex.Compile(cfg)
-	proc := NewProcessor(engine, core.GlobalContext{}, nil, "markdown")
+	proc := NewProcessor(engine, core.GlobalContext{}, nil)
 
 	file := sources.NewBufferInputFile("data.txt", []byte("lots of content\n"))
 	file.Config = core.RunnerConfig{Head: 0, Tail: 0}
@@ -166,7 +166,7 @@ func TestRender_CompactView(t *testing.T) {
 	item := PreparedItem{Raw: file, Section: &core.SectionContext{}, FileIndexGlobal: 1}
 
 	var buf bytes.Buffer
-	if err := proc.RenderPrepared(&buf, item, nil); err != nil {
+	if _, err := proc.RenderPrepared(&buf, item, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -182,7 +182,7 @@ func TestRender_CompactView(t *testing.T) {
 func TestRender_LineNumbers(t *testing.T) {
 	cfg := core.NewConfig()
 	engine, _ := templatex.Compile(cfg)
-	proc := NewProcessor(engine, core.GlobalContext{TotalFiles: 1}, nil, "markdown")
+	proc := NewProcessor(engine, core.GlobalContext{TotalFiles: 1}, nil)
 
 	file := sources.NewBufferInputFile("code.go", []byte("package main\nfunc main() {}\n"))
 	file.Config = core.RunnerConfig{Head: -1, Tail: -1, LineNumbers: true}
@@ -190,7 +190,7 @@ func TestRender_LineNumbers(t *testing.T) {
 	item := PreparedItem{Raw: file, Section: &core.SectionContext{}, FileIndexGlobal: 1}
 
 	var buf bytes.Buffer
-	if err := proc.RenderPrepared(&buf, item, nil); err != nil {
+	if _, err := proc.RenderPrepared(&buf, item, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -244,5 +244,160 @@ func TestFileFormat(t *testing.T) {
 		if got := fileFormat(path); got != want {
 			t.Errorf("fileFormat(%q) = %q, want %q", path, got, want)
 		}
+	}
+}
+
+func TestApplyConvertersLeavesContentWhenNoneApply(t *testing.T) {
+	src := []byte("package main\n")
+	file := sources.NewBufferInputFile("main.go", src)
+
+	reader, size, from := applyConverters(file, bytes.NewReader(src), int64(len(src)))
+	if from != "" {
+		t.Errorf("convertedFrom = %q, want empty", from)
+	}
+	if size != int64(len(src)) {
+		t.Errorf("size = %d, want %d", size, len(src))
+	}
+	got := make([]byte, size)
+	reader.ReadAt(got, 0)
+	if string(got) != string(src) {
+		t.Errorf("content = %q, want it untouched", got)
+	}
+}
+
+func TestApplyConvertersRunsMatchingConverter(t *testing.T) {
+	converters = append(converters, converter{
+		name:    "test",
+		applies: func(f sources.InputFile) bool { return strings.HasSuffix(f.Path, ".zzz") },
+		convert: func(path string, r io.ReaderAt, size int64) ([]byte, error) {
+			return []byte("converted"), nil
+		},
+	})
+	t.Cleanup(func() { converters = converters[:len(converters)-1] })
+
+	file := sources.NewBufferInputFile("doc.zzz", []byte("raw"))
+	reader, size, from := applyConverters(file, bytes.NewReader([]byte("raw")), 3)
+
+	if from != "zzz" {
+		t.Errorf("convertedFrom = %q, want %q", from, "zzz")
+	}
+	got := make([]byte, size)
+	reader.ReadAt(got, 0)
+	if string(got) != "converted" {
+		t.Errorf("content = %q, want %q", got, "converted")
+	}
+}
+
+// A failing converter must not lose the original content.
+func TestApplyConvertersKeepsContentOnFailure(t *testing.T) {
+	converters = append(converters, converter{
+		name:    "failing",
+		applies: func(f sources.InputFile) bool { return strings.HasSuffix(f.Path, ".zzz") },
+		convert: func(path string, r io.ReaderAt, size int64) ([]byte, error) {
+			return nil, io.ErrUnexpectedEOF
+		},
+	})
+	t.Cleanup(func() { converters = converters[:len(converters)-1] })
+
+	src := []byte("raw content")
+	reader, size, from := applyConverters(
+		sources.NewBufferInputFile("doc.zzz", src), bytes.NewReader(src), int64(len(src)))
+
+	if from != "" {
+		t.Errorf("convertedFrom = %q, want empty after a failure", from)
+	}
+	got := make([]byte, size)
+	reader.ReadAt(got, 0)
+	if string(got) != string(src) {
+		t.Errorf("content = %q, want the original %q", got, src)
+	}
+}
+
+func TestApplySkeletonReportsOriginalRowCount(t *testing.T) {
+	src := []byte("package main\n\nfunc Alpha() int {\n\treturn 1\n}\n")
+	cfg := core.RunnerConfig{Head: -1, SkeletonFunctions: true}
+
+	reader, size, mode, originalRows := applySkeleton(
+		cfg, "go", bytes.NewReader(src), int64(len(src)), false, false)
+
+	if mode != "function signatures" {
+		t.Errorf("mode = %q", mode)
+	}
+	if originalRows != 5 {
+		t.Errorf("originalRows = %d, want 5", originalRows)
+	}
+	if size >= int64(len(src)) {
+		t.Errorf("filtered size %d should be smaller than %d", size, len(src))
+	}
+	if reader == nil {
+		t.Error("reader is nil")
+	}
+}
+
+func TestApplySkeletonSkipsBinaryAndImages(t *testing.T) {
+	src := []byte("package main\nfunc A() {}\n")
+	cfg := core.RunnerConfig{Head: -1, SkeletonFunctions: true}
+
+	for _, tc := range []struct {
+		name              string
+		isBinary, isImage bool
+	}{
+		{"binary", true, false},
+		{"image", false, true},
+	} {
+		_, size, mode, originalRows := applySkeleton(
+			cfg, "go", bytes.NewReader(src), int64(len(src)), tc.isBinary, tc.isImage)
+		if mode != "" || originalRows != -1 || size != int64(len(src)) {
+			t.Errorf("%s: skeleton ran anyway (mode=%q rows=%d size=%d)", tc.name, mode, originalRows, size)
+		}
+	}
+}
+
+func TestRenderPreparedReportsStats(t *testing.T) {
+	cfg := core.NewConfig()
+	engine, _ := templatex.Compile(cfg)
+	proc := NewProcessor(engine, core.GlobalContext{}, nil)
+
+	file := sources.NewBufferInputFile("a.txt", []byte("one\ntwo\nthree\n"))
+	file.Config = core.RunnerConfig{Head: -1}
+
+	var buf bytes.Buffer
+	stats, err := proc.RenderPrepared(&buf, PreparedItem{
+		Raw: file, Section: &core.SectionContext{}, FileIndexGlobal: 1,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Rows != 3 {
+		t.Errorf("Rows = %d, want 3", stats.Rows)
+	}
+	if stats.IsBinary || stats.IsError || stats.IsCompact {
+		t.Errorf("unexpected flags: %+v", stats)
+	}
+}
+
+// Non-file items carry no stats, and must not inherit them from a prior item.
+func TestRenderPreparedNonFileItemHasZeroStats(t *testing.T) {
+	cfg := core.NewConfig()
+	engine, _ := templatex.Compile(cfg)
+	proc := NewProcessor(engine, core.GlobalContext{}, nil)
+
+	file := sources.NewBufferInputFile("a.txt", []byte("one\ntwo\n"))
+	file.Config = core.RunnerConfig{Head: -1}
+	var buf bytes.Buffer
+	if _, err := proc.RenderPrepared(&buf, PreparedItem{
+		Raw: file, Section: &core.SectionContext{}, FileIndexGlobal: 1,
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := proc.RenderPrepared(&buf, PreparedItem{
+		Raw: core.PromptContext{Body: "hi"}, Section: &core.SectionContext{},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats != (RenderStats{}) {
+		t.Errorf("prompt item reported %+v, want zero stats", stats)
 	}
 }

--- a/pkg/lx/streaming/pipeline.go
+++ b/pkg/lx/streaming/pipeline.go
@@ -41,13 +41,15 @@ func (s *Stream) executePipeline(ctx context.Context, dest *byteCounter, global 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+
+			// One processor per worker: it no longer carries per-item state.
+			proc := render.NewProcessor(s.engine, global, s.onFileError)
+			proc.SetTokenCounter(s.tokenizer.Estimate)
+
 			for j := range jobsCh {
 				if ctx.Err() != nil {
 					return
 				}
-
-				proc := render.NewProcessor(s.engine, global, s.onFileError, s.format)
-				proc.SetTokenCounter(s.tokenizer.Estimate)
 
 				readBufPtr := readPool.Get().(*[]byte)
 				readBuf := *readBufPtr
@@ -58,7 +60,7 @@ func (s *Stream) executePipeline(ctx context.Context, dest *byteCounter, global 
 				}
 				localCounter := &byteCounter{w: buf}
 
-				err := proc.RenderPrepared(localCounter, j.item, readBuf)
+				itemStats, err := proc.RenderPrepared(localCounter, j.item, readBuf)
 				readPool.Put(readBufPtr)
 
 				select {
@@ -66,10 +68,10 @@ func (s *Stream) executePipeline(ctx context.Context, dest *byteCounter, global 
 					Index:        j.seqID,
 					Buffer:       buf,
 					Stats:        localCounter.count,
-					Rows:         proc.LastRows(),
-					IsCompact:    proc.LastWasCompact(),
-					IsBinary:     proc.LastWasBinary(),
-					IsError:      proc.LastWasError(),
+					Rows:         itemStats.Rows,
+					IsCompact:    itemStats.IsCompact,
+					IsBinary:     itemStats.IsBinary,
+					IsError:      itemStats.IsError,
 					Err:          err,
 					SectionIndex: j.item.Section.Index,
 				}:
@@ -94,8 +96,7 @@ func (s *Stream) executePipeline(ctx context.Context, dest *byteCounter, global 
 		close(resultsCh)
 	}()
 
-	useSeparators := s.format != "html" && s.format != "bare"
-	layout := render.NewLayoutWriter(dest, s.engine, s.sections, useSeparators)
+	layout := render.NewLayoutWriter(dest, s.engine, s.sections, s.engine.UseSeparators)
 	defer layout.Close()
 
 	nextSeq := 0

--- a/pkg/lx/streaming/stream.go
+++ b/pkg/lx/streaming/stream.go
@@ -28,7 +28,6 @@ type Stream struct {
 	engine      *core.TemplateEngine
 	renderCfg   core.RunnerConfig
 	workDir     string
-	format      string
 	finalStats  *core.GlobalContext
 	sections    []*core.SectionContext
 	onFileError FileErrorHandler
@@ -44,17 +43,11 @@ func NewStream(cfg *core.Config, runnerCfg core.RunnerConfig) (*Stream, error) {
 		return nil, err
 	}
 
-	fmtType := cfg.OutputFormat
-	if fmtType == "" {
-		fmtType = "markdown"
-	}
-
 	return &Stream{
 		engine:      engine,
 		renderCfg:   runnerCfg,
 		tokenizer:   defaultTokenizer{},
 		workDir:     ".",
-		format:      fmtType,
 		concurrency: runtime.NumCPU(),
 	}, nil
 }

--- a/pkg/lx/templatex/compile.go
+++ b/pkg/lx/templatex/compile.go
@@ -99,11 +99,18 @@ func Compile(cfg *core.Config) (*core.TemplateEngine, error) {
 		return nil, fmt.Errorf("stats template: %w", err)
 	}
 
+	// HTML embeds images inline; every other format reports them like binaries.
+	tImage := tBinary
+	if format == "html" {
+		tImage = tContent
+	}
+
 	return &core.TemplateEngine{
 		FileContent:   tContent,
 		FileError:     tError,
 		FileBinary:    tBinary,
 		FileCompact:   tCompact,
+		FileImage:     tImage,
 		Section:       tSection,
 		Prompt:        tPrompt,
 		Tree:          tTree,
@@ -113,5 +120,7 @@ func Compile(cfg *core.Config) (*core.TemplateEngine, error) {
 		OutputHeader:  tHeader,
 		OutputFooter:  tFooter,
 		Stats:         tStats,
+		EmbedImages:   format == "html",
+		UseSeparators: format != "html" && format != "bare",
 	}, nil
 }


### PR DESCRIPTION
Three related refactors, all output-neutral. No golden file moved.

Format policy moves to the template engine: Compile resolves FileImage, EmbedImages and UseSeparators per format, so the processor no longer compares format strings and Processor.format and Stream.format are gone.

RenderPrepared returns RenderStats instead of leaving four fields on the Processor behind LastX getters. The worker now allocates one Processor rather than one per item, and an early-return branch no longer leaves stale state behind.

Content transforms become a registry: document extraction is an entry in converters, and skeleton filtering moves to applySkeleton. Converters select on the path and run before detection; skeleton runs after because it needs the language. parse-html and extract-media are one entry each rather than another branch, and prepareFileContext drops from 120 lines to 79.