### PR TITLE
refactor: remove duplicated config and token scanner code

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -11,25 +11,9 @@ import (
 )
 
 type CliConfig struct {
-	FileContentTemplate string `yaml:"file_content_template"`
-	FileErrorTemplate   string `yaml:"file_error_template"`
-	FileBinaryTemplate  string `yaml:"file_binary_template"`
-	FileCompactTemplate string `yaml:"file_compact_template"`
-	FileHeaderTemplate  string `yaml:"file_header_template"`
-
-	SectionTemplate string `yaml:"section_template"`
-	PromptTemplate  string `yaml:"prompt_template"`
-	TreeTemplate    string `yaml:"tree_template"`
-	MetaTemplate    string `yaml:"meta_template"`
-
-	SectionHeaderTemplate string `yaml:"section_header_template"`
-	SectionFooterTemplate string `yaml:"section_footer_template"`
-
-	OutputHeaderTemplate string `yaml:"output_header_template"`
-	OutputFooterTemplate string `yaml:"output_footer_template"`
-	StatsTemplate        string `yaml:"stats_template"`
-
-	OutputFormat string `yaml:"output_format"`
+	// The library config keys are inlined from their single definition in
+	// core.Config, so adding a template needs no change here.
+	lx.Config `yaml:",inline"`
 
 	OutputMode string `yaml:"output_mode"`
 	ShowStats  string `yaml:"show_stats"`
@@ -74,25 +58,7 @@ func LoadConfigChain(cliPath string) (*lx.Config, *CliConfig, error) {
 			return err
 		}
 
-		overrideIfSet(&lxCfg.FileContentTemplate, loaded.FileContentTemplate)
-		overrideIfSet(&lxCfg.FileErrorTemplate, loaded.FileErrorTemplate)
-		overrideIfSet(&lxCfg.FileBinaryTemplate, loaded.FileBinaryTemplate)
-		overrideIfSet(&lxCfg.FileCompactTemplate, loaded.FileCompactTemplate)
-		overrideIfSet(&lxCfg.FileHeaderTemplate, loaded.FileHeaderTemplate)
-
-		overrideIfSet(&lxCfg.SectionTemplate, loaded.SectionTemplate)
-		overrideIfSet(&lxCfg.PromptTemplate, loaded.PromptTemplate)
-		overrideIfSet(&lxCfg.TreeTemplate, loaded.TreeTemplate)
-		overrideIfSet(&lxCfg.MetaTemplate, loaded.MetaTemplate)
-
-		overrideIfSet(&lxCfg.SectionHeaderTemplate, loaded.SectionHeaderTemplate)
-		overrideIfSet(&lxCfg.SectionFooterTemplate, loaded.SectionFooterTemplate)
-
-		overrideIfSet(&lxCfg.OutputHeaderTemplate, loaded.OutputHeaderTemplate)
-		overrideIfSet(&lxCfg.OutputFooterTemplate, loaded.OutputFooterTemplate)
-		overrideIfSet(&lxCfg.StatsTemplate, loaded.StatsTemplate)
-
-		overrideIfSet(&lxCfg.OutputFormat, loaded.OutputFormat)
+		lx.Merge(lxCfg, &loaded.Config)
 
 		overrideIfSet(&mergedCli.OutputMode, loaded.OutputMode)
 		overrideIfSet(&mergedCli.ShowStats, loaded.ShowStats)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,0 +1,87 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/rasros/lx/pkg/lx"
+)
+
+// The keys are listed by hand on purpose: they restate the documented schema
+// independently of the struct tags, so a mistyped tag leaves its field empty
+// here rather than silently dropping a user's setting.
+const everyConfigKey = `
+file_content_template: "x"
+file_error_template: "x"
+file_binary_template: "x"
+file_compact_template: "x"
+file_header_template: "x"
+section_template: "x"
+prompt_template: "x"
+tree_template: "x"
+meta_template: "x"
+section_header_template: "x"
+section_footer_template: "x"
+output_header_template: "x"
+output_footer_template: "x"
+stats_template: "x"
+output_format: "xml"
+output_mode: "copy"
+show_stats: "always"
+verbosity: "debug"
+prompts_dir: "/tmp/prompts"
+prompt_extensions: [".md"]
+`
+
+func loadFrom(t *testing.T, yaml string) (*lx.Config, *CliConfig) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("LX_CONFIG", "")
+
+	lxCfg, cliCfg, err := LoadConfigChain(path)
+	if err != nil {
+		t.Fatalf("LoadConfigChain failed: %v", err)
+	}
+	return lxCfg, cliCfg
+}
+
+func TestLoadConfigChainAcceptsEveryKey(t *testing.T) {
+	lxCfg, cliCfg := loadFrom(t, everyConfigKey)
+
+	v := reflect.ValueOf(lxCfg).Elem()
+	for i := 0; i < v.NumField(); i++ {
+		if v.Field(i).String() == "" {
+			t.Errorf("%s stayed empty; check its yaml tag", v.Type().Field(i).Name)
+		}
+	}
+
+	if cliCfg.OutputMode != "copy" || cliCfg.ShowStats != "always" ||
+		cliCfg.Verbosity != "debug" || cliCfg.PromptsDir != "/tmp/prompts" ||
+		len(cliCfg.PromptExtensions) != 1 {
+		t.Errorf("cli-only keys not applied: %+v", cliCfg)
+	}
+}
+
+func TestLoadConfigChainKeepsDefaultsForAbsentKeys(t *testing.T) {
+	lxCfg, cliCfg := loadFrom(t, "verbosity: info\n")
+
+	if cliCfg.Verbosity != "info" {
+		t.Errorf("Verbosity = %q, want info", cliCfg.Verbosity)
+	}
+	if cliCfg.OutputMode != "stdout" {
+		t.Errorf("OutputMode = %q, want the stdout default", cliCfg.OutputMode)
+	}
+	if lxCfg.OutputFormat != "markdown" {
+		t.Errorf("OutputFormat = %q, want the markdown default", lxCfg.OutputFormat)
+	}
+	if lxCfg.FileContentTemplate != "" {
+		t.Errorf("FileContentTemplate = %q, want empty so the format default applies", lxCfg.FileContentTemplate)
+	}
+}

--- a/pkg/lx/core/config.go
+++ b/pkg/lx/core/config.go
@@ -1,5 +1,7 @@
 package core
 
+import "reflect"
+
 // NewConfig returns a default configuration.
 func NewConfig() *Config {
 	return &Config{
@@ -7,55 +9,15 @@ func NewConfig() *Config {
 	}
 }
 
-// Merge applies non-zero fields from src to dst.
+// Merge applies non-zero fields from src to dst. Every field is a string, so
+// "set" and "non-zero" coincide; a future non-string field whose zero value is
+// meaningful would need explicit handling.
 func Merge(dst *Config, src *Config) {
-	if src.FileContentTemplate != "" {
-		dst.FileContentTemplate = src.FileContentTemplate
-	}
-	if src.FileErrorTemplate != "" {
-		dst.FileErrorTemplate = src.FileErrorTemplate
-	}
-	if src.FileBinaryTemplate != "" {
-		dst.FileBinaryTemplate = src.FileBinaryTemplate
-	}
-	if src.FileCompactTemplate != "" {
-		dst.FileCompactTemplate = src.FileCompactTemplate
-	}
-	if src.FileHeaderTemplate != "" {
-		dst.FileHeaderTemplate = src.FileHeaderTemplate
-	}
-
-	if src.SectionTemplate != "" {
-		dst.SectionTemplate = src.SectionTemplate
-	}
-	if src.PromptTemplate != "" {
-		dst.PromptTemplate = src.PromptTemplate
-	}
-	if src.TreeTemplate != "" {
-		dst.TreeTemplate = src.TreeTemplate
-	}
-	if src.MetaTemplate != "" {
-		dst.MetaTemplate = src.MetaTemplate
-	}
-
-	if src.SectionHeaderTemplate != "" {
-		dst.SectionHeaderTemplate = src.SectionHeaderTemplate
-	}
-	if src.SectionFooterTemplate != "" {
-		dst.SectionFooterTemplate = src.SectionFooterTemplate
-	}
-
-	if src.OutputHeaderTemplate != "" {
-		dst.OutputHeaderTemplate = src.OutputHeaderTemplate
-	}
-	if src.OutputFooterTemplate != "" {
-		dst.OutputFooterTemplate = src.OutputFooterTemplate
-	}
-	if src.StatsTemplate != "" {
-		dst.StatsTemplate = src.StatsTemplate
-	}
-
-	if src.OutputFormat != "" {
-		dst.OutputFormat = src.OutputFormat
+	d := reflect.ValueOf(dst).Elem()
+	s := reflect.ValueOf(src).Elem()
+	for i := 0; i < s.NumField(); i++ {
+		if f := s.Field(i); !f.IsZero() {
+			d.Field(i).Set(f)
+		}
 	}
 }

--- a/pkg/lx/core/token.go
+++ b/pkg/lx/core/token.go
@@ -16,92 +16,50 @@ const (
 func DefaultTokenCounter(size int64, content interface{}) int64 {
 	switch v := content.(type) {
 	case string:
-		return estimateString(v, size)
+		return estimate(v, size)
 	case []byte:
-		return estimateBytes(v, size)
+		return estimate(v, size)
 	case fmt.Stringer:
-		return estimateString(v.String(), size)
+		return estimate(v.String(), size)
 	}
 	return size / 4
 }
 
-func estimateString(s string, size int64) int64 {
-	n := int64(len(s))
+// byteseq is the pair of representations content arrives in. Scanning them with
+// one implementation keeps the two from drifting apart.
+type byteseq interface {
+	~string | ~[]byte
+}
+
+// estimate scans the whole content when it is small enough, and otherwise
+// extrapolates from a head and tail sample.
+func estimate[T byteseq](d T, size int64) int64 {
+	n := int64(len(d))
 	if n == 0 {
 		return size / 4
 	}
 	if n <= sampleThreshold {
-		return scanString(s)
+		return scan(d)
 	}
+
 	headEnd := sampleHead
-	tailStart := len(s) - sampleTail
+	tailStart := len(d) - sampleTail
 	if tailStart < headEnd {
-		return scanString(s)
+		return scan(d)
 	}
-	sampleTokens := scanString(s[:headEnd]) + scanString(s[tailStart:])
+
+	sampleTokens := scan(d[:headEnd]) + scan(d[tailStart:])
 	sampleBytes := int64(headEnd + sampleTail)
 	return sampleTokens * n / sampleBytes
 }
 
-func estimateBytes(b []byte, size int64) int64 {
-	n := int64(len(b))
-	if n == 0 {
-		return size / 4
-	}
-	if n <= sampleThreshold {
-		return scanBytes(b)
-	}
-	headEnd := sampleHead
-	tailStart := len(b) - sampleTail
-	if tailStart < headEnd {
-		return scanBytes(b)
-	}
-	sampleTokens := scanBytes(b[:headEnd]) + scanBytes(b[tailStart:])
-	sampleBytes := int64(headEnd + sampleTail)
-	return sampleTokens * n / sampleBytes
-}
-
-func scanString(s string) int64 {
+func scan[T byteseq](d T) int64 {
 	var (
 		wordRuns, wordChars, symbols, wsRuns, newlines, nonAscii int64
 		inWord, inWS                                             bool
 	)
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		switch {
-		case c >= 0x80:
-			nonAscii++
-			inWord, inWS = false, false
-		case isWord(c):
-			if !inWord {
-				wordRuns++
-				inWord = true
-			}
-			wordChars++
-			inWS = false
-		case c == '\n':
-			newlines++
-			inWord, inWS = false, false
-		case isWS(c):
-			if !inWS {
-				wsRuns++
-				inWS = true
-			}
-			inWord = false
-		default:
-			symbols++
-			inWord, inWS = false, false
-		}
-	}
-	return combine(wordRuns, wordChars, symbols, wsRuns, newlines, nonAscii)
-}
-
-func scanBytes(b []byte) int64 {
-	var (
-		wordRuns, wordChars, symbols, wsRuns, newlines, nonAscii int64
-		inWord, inWS                                             bool
-	)
-	for _, c := range b {
+	for i := 0; i < len(d); i++ {
+		c := d[i]
 		switch {
 		case c >= 0x80:
 			nonAscii++

--- a/pkg/lx/core/token_test.go
+++ b/pkg/lx/core/token_test.go
@@ -104,7 +104,7 @@ func TestDefaultTokenCounter_LargeContentSampling(t *testing.T) {
 
 	// Same content scanned without sampling: feed it as a slice that's exactly
 	// the content but invoke the inner scanner directly via a sub-threshold split.
-	exact := scanString(full)
+	exact := scan(full)
 
 	diff := sampled - exact
 	if diff < 0 {
@@ -161,5 +161,27 @@ func TestDefaultTokenCounter_DensityFollowsSymbolShare(t *testing.T) {
 	}
 	if jsonWords >= prose {
 		t.Errorf("JSON of long string values (%.2f) should still beat prose (%.2f)", jsonWords, prose)
+	}
+}
+
+// The two representations shared duplicated scanners before; this pins that one
+// implementation now serves both.
+func TestDefaultTokenCounterAgreesAcrossRepresentations(t *testing.T) {
+	samples := []string{
+		"",
+		"hello world",
+		strings.Repeat(`{"a":1,"b":[true,false]},`, 40),
+		strings.Repeat("func Alpha() int {\n\treturn 1\n}\n", 40),
+		strings.Repeat("naïve café — résumé ", 40),
+		strings.Repeat("x", sampleThreshold+sampleHead+sampleTail+1),
+	}
+
+	for i, s := range samples {
+		size := int64(len(s))
+		fromString := DefaultTokenCounter(size, s)
+		fromBytes := DefaultTokenCounter(size, []byte(s))
+		if fromString != fromBytes {
+			t.Errorf("sample %d: string gave %d, []byte gave %d", i, fromString, fromBytes)
+		}
 	}
 }

--- a/pkg/lx/core/types.go
+++ b/pkg/lx/core/types.go
@@ -63,27 +63,29 @@ type TemplateEngine struct {
 	UseSeparators bool
 }
 
-// Config represents the core library configuration.
+// Config represents the core library configuration. The yaml tags are the
+// documented config-file keys, so this struct is the single definition of that
+// schema.
 type Config struct {
-	FileContentTemplate string
-	FileErrorTemplate   string
-	FileBinaryTemplate  string
-	FileCompactTemplate string
-	FileHeaderTemplate  string
+	FileContentTemplate string `yaml:"file_content_template"`
+	FileErrorTemplate   string `yaml:"file_error_template"`
+	FileBinaryTemplate  string `yaml:"file_binary_template"`
+	FileCompactTemplate string `yaml:"file_compact_template"`
+	FileHeaderTemplate  string `yaml:"file_header_template"`
 
-	SectionTemplate string
-	PromptTemplate  string
-	TreeTemplate    string
-	MetaTemplate    string
+	SectionTemplate string `yaml:"section_template"`
+	PromptTemplate  string `yaml:"prompt_template"`
+	TreeTemplate    string `yaml:"tree_template"`
+	MetaTemplate    string `yaml:"meta_template"`
 
-	SectionHeaderTemplate string
-	SectionFooterTemplate string
+	SectionHeaderTemplate string `yaml:"section_header_template"`
+	SectionFooterTemplate string `yaml:"section_footer_template"`
 
-	OutputHeaderTemplate string
-	OutputFooterTemplate string
-	StatsTemplate        string
+	OutputHeaderTemplate string `yaml:"output_header_template"`
+	OutputFooterTemplate string `yaml:"output_footer_template"`
+	StatsTemplate        string `yaml:"stats_template"`
 
-	OutputFormat string
+	OutputFormat string `yaml:"output_format"`
 }
 
 // FileContext represents the data provided to file-level templates.

--- a/pkg/lx/facade.go
+++ b/pkg/lx/facade.go
@@ -27,6 +27,8 @@ type FileErrorHandler = streamingpkg.FileErrorHandler
 
 func NewConfig() *Config { return core.NewConfig() }
 
+func Merge(dst *Config, src *Config) { core.Merge(dst, src) }
+
 func NewWalker(basePatterns, overridePatterns []string) *Walker {
 	return walkerpkg.NewWalker(basePatterns, overridePatterns)
 }


### PR DESCRIPTION
Two independent bits of hand-maintained duplication. Output-neutral, no golden file moved.

CliConfig declared all fifteen template fields a second time and copied them across with fifteen overrideIfSet calls. Adding a template meant editing five places, and a forgotten copy line compiled fine while silently ignoring the user's config. core.Config now carries the yaml tags, so it is the single definition of the schema, and CliConfig inlines it. Merge became reflective, which removes the other per-field list.

scanString and scanBytes were byte-identical apart from the loop header, as were estimateString and estimateBytes. They are now one generic pair over ~string | ~[]byte. token.go drops from 155 lines to 115.

Verified the two shipped profiles produce byte-identical output before and after. Added a config test that asserts every documented key round-trips and fails if a core.Config field is left uncovered, since a mistyped yaml tag has no compile-time signal.