### PR TITLE
refactor: resolve file inputs once for both passes

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -178,10 +177,15 @@ func processStream(ctx context.Context, parsed *ParsedArgs, rawArgs []string) er
 	promptResolver := newPromptResolver(resolvePromptsDir(parsed, cliOpts), cliOpts.PromptExtensions)
 	sections := parseSections(parsed.Ops, defaultRunCfg)
 	applyWorkloadConcurrency(stream, sections, runtime.NumCPU())
-	precomputeTrees(ctx, sections, globalIgnoreRules)
 	debugLoggingEnabled := slog.Default().Enabled(ctx, slog.LevelDebug)
 
-	unresolved := 0
+	unresolved := resolveSections(ctx, sections, resolveContext{
+		ignoreRules: globalIgnoreRules,
+		outPath:     outPath,
+		debug:       debugLoggingEnabled,
+		cleanups:    &tempCleanups,
+	})
+	precomputeTrees(sections)
 	var metaFields map[string]string
 	var metaBody string
 	resolveSystemContext := func() (map[string]string, string) {
@@ -194,7 +198,6 @@ func processStream(ctx context.Context, parsed *ParsedArgs, rawArgs []string) er
 	for si, section := range sections {
 		slog.Debug("Processing section", "index", si, "ops", len(section.Ops))
 		stream.WithRunnerConfig(section.RunCfg)
-		includeSpecs := lx.CompileSpecs(section.Includes)
 
 		for oi, op := range section.Ops {
 			slog.Debug("Processing op", "action", op.Action, "value", op.Value)
@@ -217,233 +220,9 @@ func processStream(ctx context.Context, parsed *ParsedArgs, rawArgs []string) er
 					continue
 				}
 
-				rawPath := op.Value
-				isForced := op.Action == "file"
-
-				forceExpand := false
-				if rewritten, ok := lx.RewriteRepoURL(rawPath); ok {
-					slog.Debug("Rewrote repo URL to archive", "from", rawPath, "to", rewritten)
-					rawPath = rewritten
-					forceExpand = true
-				}
-
-				if lx.IsHTTPURL(rawPath) {
-					if (section.RunCfg.ExpandArchives || forceExpand) && lx.IsHTTPArchiveURL(rawPath) {
-						if !isForced && !lx.IsKept(rawPath, nil, section.Excludes) {
-							slog.Debug("Skipping URL archive due to exclude filter", "url", rawPath)
-							continue
-						}
-
-						tempPath, cleanup, err := lx.DownloadURLToTempFile(ctx, rawPath)
-						if err != nil {
-							slog.Error("Failed to download URL archive", "url", rawPath, "error", err)
-							continue
-						}
-						tempCleanups = append(tempCleanups, cleanup)
-
-						archiveWalker := newArchiveWalker(section.RunCfg.ShowHidden, isForced)
-						if debugLoggingEnabled {
-							archiveWalker.OnIgnore = func(p, reason string) {
-								slog.Debug("Ignored in URL archive", "path", rawPath+"/"+p, "reason", reason)
-							}
-						}
-						archiveIncludes := section.Includes
-						if isForced {
-							archiveIncludes = nil
-						}
-						if err := lx.ExpandArchive(ctx, tempPath, rawPath, archiveWalker, archiveIncludes, outPath, stream); err != nil {
-							slog.Error("Failed to expand URL archive", "url", rawPath, "error", err)
-						}
-						continue
-					}
-
-					if !isForced && !lx.IsKept(rawPath, section.Includes, section.Excludes) {
-						slog.Debug("Skipping URL due to filters", "url", rawPath)
-						continue
-					}
-					urlFile, err := lx.NewURLInputFile(rawPath)
-					if err != nil {
-						slog.Error("Failed to create URL input", "url", rawPath, "error", err)
-						continue
-					}
-					slog.Debug("URL accepted", "url", urlFile.Path)
-					stream.AddFile(urlFile)
-					continue
-				}
-
-				var fsys fs.FS
-				var walkRoot string
-				var displayPrefix string
-
-				absPath, err := filepath.Abs(rawPath)
-				if err != nil {
-					slog.Error("Failed to resolve absolute path", "path", rawPath, "error", err)
-					unresolved++
-					continue
-				}
-
-				stat, err := os.Stat(absPath)
-				if err != nil {
-					if !isForced && !lx.IsKept(rawPath, section.Includes, section.Excludes) {
-						slog.Debug("Skipping missing path due to filters", "path", rawPath)
-						continue
-					}
-					slog.Error("Failed to stat path", "path", absPath, "error", err)
-					unresolved++
-					continue
-				}
-
-				if !stat.IsDir() {
-					isExpandableArchive := section.RunCfg.ExpandArchives && lx.IsArchivePath(rawPath)
-					if !isForced && !isExpandableArchive && !lx.IsKept(rawPath, section.Includes, section.Excludes) {
-						slog.Debug("Skipping file due to filters", "path", rawPath)
-						continue
-					}
-					if !isForced && isExpandableArchive && !lx.IsKept(rawPath, nil, section.Excludes) {
-						slog.Debug("Skipping archive due to exclude filter", "path", rawPath)
-						continue
-					}
-
-					rawPathClean := filepath.Clean(rawPath)
-
-					if !filepath.IsAbs(rawPathClean) && !strings.HasPrefix(rawPathClean, "..") {
-						fsys = os.DirFS(".")
-						walkRoot = filepath.ToSlash(rawPathClean)
-					} else {
-						fsys = os.DirFS(filepath.Dir(absPath))
-						walkRoot = filepath.Base(absPath)
-						displayPrefix = filepath.Dir(rawPathClean)
-					}
-				} else {
-					fsys = os.DirFS(absPath)
-					walkRoot = "."
-					displayPrefix = filepath.Clean(rawPath)
-				}
-
-				var baseRules []string
-				var overrideRules []string
-
-				if !section.RunCfg.NoIgnore {
-					baseRules = append(baseRules, globalIgnoreRules...)
-				}
-
-				if !isForced {
-					overrideRules = append(overrideRules, section.Excludes...)
-				}
-
-				slog.Debug("Initializing Walker",
-					"walk_root", walkRoot,
-					"base_rules_count", len(baseRules),
-					"override_rules_count", len(overrideRules),
-					"is_forced", isForced,
-				)
-
-				walker := lx.NewWalker(baseRules, overrideRules)
-				walker.IgnoreEnabled = !section.RunCfg.NoIgnore
-				walker.SkipHidden = !section.RunCfg.ShowHidden && !isForced
-				walker.FollowDirSymlinks = section.RunCfg.FollowDirSymlinks
-				walker.SkipFileSymlinks = section.RunCfg.SkipFileSymlinks
-				if debugLoggingEnabled {
-					walker.OnIgnore = func(p, reason string) {
-						slog.Debug("Ignored", "path", p, "reason", reason)
-					}
-				}
-
-				count := 0
-
-				err = walker.Walk(fsys, walkRoot, func(path string, d fs.DirEntry, err error) error {
-					if err != nil {
-						slog.Warn("Error accessing path during walk", "path", path, "error", err)
-						return nil
-					}
-					if d.IsDir() {
-						if !isForced && len(includeSpecs) > 0 && path != "." && !lx.CouldMatchAnyDescendant(includeSpecs, path) {
-							return fs.SkipDir
-						}
-						return nil
-					}
-
-					var effectivePath string
-					if !stat.IsDir() {
-						if displayPrefix != "" {
-							effectivePath = filepath.Join(displayPrefix, filepath.FromSlash(path))
-						} else {
-							effectivePath = filepath.FromSlash(path)
-						}
-					} else {
-						if path == "." {
-							effectivePath = displayPrefix
-						} else {
-							effectivePath = filepath.Join(displayPrefix, filepath.FromSlash(path))
-						}
-					}
-
-					if section.RunCfg.ExpandArchives && lx.IsArchivePath(path) {
-						var archiveAbsPath string
-						if stat.IsDir() {
-							archiveAbsPath = filepath.Join(absPath, filepath.FromSlash(path))
-						} else {
-							archiveAbsPath = absPath
-						}
-						archiveWalker := newArchiveWalker(section.RunCfg.ShowHidden, isForced)
-						if debugLoggingEnabled {
-							archiveWalker.OnIgnore = func(p, reason string) {
-								slog.Debug("Ignored in archive", "path", effectivePath+"/"+p, "reason", reason)
-							}
-						}
-						archiveIncludes := section.Includes
-						if isForced {
-							archiveIncludes = nil
-						}
-						if err := lx.ExpandArchive(ctx, archiveAbsPath, effectivePath, archiveWalker, archiveIncludes, outPath, stream); err != nil {
-							slog.Error("Failed to expand archive", "path", effectivePath, "error", err)
-						}
-						return nil
-					}
-
-					if !isForced && len(includeSpecs) > 0 {
-						if !lx.IsMatchAnyCompiled(includeSpecs, path) {
-							slog.Debug("Ignored by include filter (-i)", "path", effectivePath)
-							return nil
-						}
-					}
-
-					if outPath != "" {
-						if abs, _ := filepath.Abs(effectivePath); abs == outPath {
-							slog.Warn("Skipping output file to avoid infinite recursion", "path", effectivePath)
-							return nil
-						}
-					}
-
-					info, err := d.Info()
-					if err != nil {
-						slog.Error("Failed to stat file in walk", "path", path, "error", err)
-						return nil
-					}
-
-					f := lx.NewInputFile(fsys, path, info)
-					f.Path = effectivePath
-
-					if !stat.IsDir() {
-						if displayPrefix != "" {
-							f.AbsPath = filepath.Join(filepath.Dir(absPath), path)
-						} else {
-							f.AbsPath = absPath
-						}
-					} else {
-						f.AbsPath = filepath.Join(absPath, path)
-					}
-
-					slog.Debug("File accepted by walker", "path", f.Path, "size", f.Size)
+				for _, f := range section.resolved[oi] {
 					stream.AddFile(f)
-					count++
-					return nil
-				})
-
-				if err != nil {
-					slog.Error("Walker traversal failed", "error", err)
 				}
-				slog.Debug("Walker finished", "root", rawPath, "files_matched", count)
 
 			case "tree", "tree-only":
 				if ts, ok := section.treeStrings[oi]; ok {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -11,25 +11,9 @@ import (
 )
 
 type CliConfig struct {
-	FileContentTemplate string `yaml:"file_content_template"`
-	FileErrorTemplate   string `yaml:"file_error_template"`
-	FileBinaryTemplate  string `yaml:"file_binary_template"`
-	FileCompactTemplate string `yaml:"file_compact_template"`
-	FileHeaderTemplate  string `yaml:"file_header_template"`
-
-	SectionTemplate string `yaml:"section_template"`
-	PromptTemplate  string `yaml:"prompt_template"`
-	TreeTemplate    string `yaml:"tree_template"`
-	MetaTemplate    string `yaml:"meta_template"`
-
-	SectionHeaderTemplate string `yaml:"section_header_template"`
-	SectionFooterTemplate string `yaml:"section_footer_template"`
-
-	OutputHeaderTemplate string `yaml:"output_header_template"`
-	OutputFooterTemplate string `yaml:"output_footer_template"`
-	StatsTemplate        string `yaml:"stats_template"`
-
-	OutputFormat string `yaml:"output_format"`
+	// The library config keys are inlined from their single definition in
+	// core.Config, so adding a template needs no change here.
+	lx.Config `yaml:",inline"`
 
 	OutputMode string `yaml:"output_mode"`
 	ShowStats  string `yaml:"show_stats"`
@@ -74,25 +58,7 @@ func LoadConfigChain(cliPath string) (*lx.Config, *CliConfig, error) {
 			return err
 		}
 
-		overrideIfSet(&lxCfg.FileContentTemplate, loaded.FileContentTemplate)
-		overrideIfSet(&lxCfg.FileErrorTemplate, loaded.FileErrorTemplate)
-		overrideIfSet(&lxCfg.FileBinaryTemplate, loaded.FileBinaryTemplate)
-		overrideIfSet(&lxCfg.FileCompactTemplate, loaded.FileCompactTemplate)
-		overrideIfSet(&lxCfg.FileHeaderTemplate, loaded.FileHeaderTemplate)
-
-		overrideIfSet(&lxCfg.SectionTemplate, loaded.SectionTemplate)
-		overrideIfSet(&lxCfg.PromptTemplate, loaded.PromptTemplate)
-		overrideIfSet(&lxCfg.TreeTemplate, loaded.TreeTemplate)
-		overrideIfSet(&lxCfg.MetaTemplate, loaded.MetaTemplate)
-
-		overrideIfSet(&lxCfg.SectionHeaderTemplate, loaded.SectionHeaderTemplate)
-		overrideIfSet(&lxCfg.SectionFooterTemplate, loaded.SectionFooterTemplate)
-
-		overrideIfSet(&lxCfg.OutputHeaderTemplate, loaded.OutputHeaderTemplate)
-		overrideIfSet(&lxCfg.OutputFooterTemplate, loaded.OutputFooterTemplate)
-		overrideIfSet(&lxCfg.StatsTemplate, loaded.StatsTemplate)
-
-		overrideIfSet(&lxCfg.OutputFormat, loaded.OutputFormat)
+		lx.Merge(lxCfg, &loaded.Config)
 
 		overrideIfSet(&mergedCli.OutputMode, loaded.OutputMode)
 		overrideIfSet(&mergedCli.ShowStats, loaded.ShowStats)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,0 +1,87 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/rasros/lx/pkg/lx"
+)
+
+// The keys are listed by hand on purpose: they restate the documented schema
+// independently of the struct tags, so a mistyped tag leaves its field empty
+// here rather than silently dropping a user's setting.
+const everyConfigKey = `
+file_content_template: "x"
+file_error_template: "x"
+file_binary_template: "x"
+file_compact_template: "x"
+file_header_template: "x"
+section_template: "x"
+prompt_template: "x"
+tree_template: "x"
+meta_template: "x"
+section_header_template: "x"
+section_footer_template: "x"
+output_header_template: "x"
+output_footer_template: "x"
+stats_template: "x"
+output_format: "xml"
+output_mode: "copy"
+show_stats: "always"
+verbosity: "debug"
+prompts_dir: "/tmp/prompts"
+prompt_extensions: [".md"]
+`
+
+func loadFrom(t *testing.T, yaml string) (*lx.Config, *CliConfig) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("LX_CONFIG", "")
+
+	lxCfg, cliCfg, err := LoadConfigChain(path)
+	if err != nil {
+		t.Fatalf("LoadConfigChain failed: %v", err)
+	}
+	return lxCfg, cliCfg
+}
+
+func TestLoadConfigChainAcceptsEveryKey(t *testing.T) {
+	lxCfg, cliCfg := loadFrom(t, everyConfigKey)
+
+	v := reflect.ValueOf(lxCfg).Elem()
+	for i := 0; i < v.NumField(); i++ {
+		if v.Field(i).String() == "" {
+			t.Errorf("%s stayed empty; check its yaml tag", v.Type().Field(i).Name)
+		}
+	}
+
+	if cliCfg.OutputMode != "copy" || cliCfg.ShowStats != "always" ||
+		cliCfg.Verbosity != "debug" || cliCfg.PromptsDir != "/tmp/prompts" ||
+		len(cliCfg.PromptExtensions) != 1 {
+		t.Errorf("cli-only keys not applied: %+v", cliCfg)
+	}
+}
+
+func TestLoadConfigChainKeepsDefaultsForAbsentKeys(t *testing.T) {
+	lxCfg, cliCfg := loadFrom(t, "verbosity: info\n")
+
+	if cliCfg.Verbosity != "info" {
+		t.Errorf("Verbosity = %q, want info", cliCfg.Verbosity)
+	}
+	if cliCfg.OutputMode != "stdout" {
+		t.Errorf("OutputMode = %q, want the stdout default", cliCfg.OutputMode)
+	}
+	if lxCfg.OutputFormat != "markdown" {
+		t.Errorf("OutputFormat = %q, want the markdown default", lxCfg.OutputFormat)
+	}
+	if lxCfg.FileContentTemplate != "" {
+		t.Errorf("FileContentTemplate = %q, want empty so the format default applies", lxCfg.FileContentTemplate)
+	}
+}

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -1,0 +1,304 @@
+package cli
+
+import (
+	"context"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rasros/lx/pkg/lx"
+)
+
+// fileCollector gathers expanded archive entries.
+type fileCollector struct{ files []lx.InputFile }
+
+func (c *fileCollector) Add(f lx.InputFile) { c.files = append(c.files, f) }
+
+// resolveSections resolves every file op once, before rendering, so the tree
+// builder and the content pass share one view of what each path refers to.
+func resolveSections(ctx context.Context, sections []Section, rc resolveContext) int {
+	unresolved := 0
+	for si := range sections {
+		rc.section = sections[si]
+		for oi, op := range sections[si].Ops {
+			if op.Action != "FILE" && op.Action != "file" {
+				continue
+			}
+			files, missing := resolveOp(ctx, op, rc)
+			unresolved += missing
+			if len(files) == 0 {
+				continue
+			}
+			if sections[si].resolved == nil {
+				sections[si].resolved = make(map[int][]lx.InputFile)
+			}
+			sections[si].resolved[oi] = files
+		}
+	}
+	return unresolved
+}
+
+// resolveContext carries the per-section state discovery depends on.
+type resolveContext struct {
+	section     Section
+	ignoreRules []string
+	outPath     string
+	debug       bool
+	cleanups    *[]func()
+}
+
+// resolveOp discovers every input one file argument refers to. The content pass
+// and the tree builder both consume the result, so the filesystem is walked once
+// and the two cannot disagree about what a path means.
+//
+// Stdin ("-") resolves to nothing: it is a buffer, not a discoverable path, and
+// it can only be read once. The content pass handles it directly.
+func resolveOp(ctx context.Context, op Op, rc resolveContext) (files []lx.InputFile, unresolved int) {
+	section := rc.section
+	rawPath := op.Value
+	if rawPath == "-" {
+		return nil, 0
+	}
+	isForced := op.Action == "file"
+
+	forceExpand := false
+	if rewritten, ok := lx.RewriteRepoURL(rawPath); ok {
+		slog.Debug("Rewrote repo URL to archive", "from", rawPath, "to", rewritten)
+		rawPath = rewritten
+		forceExpand = true
+	}
+
+	if lx.IsHTTPURL(rawPath) {
+		return resolveURL(ctx, rawPath, isForced, forceExpand, rc)
+	}
+
+	absPath, err := filepath.Abs(rawPath)
+	if err != nil {
+		slog.Error("Failed to resolve absolute path", "path", rawPath, "error", err)
+		return nil, 1
+	}
+
+	stat, err := os.Stat(absPath)
+	if err != nil {
+		if !isForced && !lx.IsKept(rawPath, section.Includes, section.Excludes) {
+			slog.Debug("Skipping missing path due to filters", "path", rawPath)
+			return nil, 0
+		}
+		slog.Error("Failed to stat path", "path", absPath, "error", err)
+		return nil, 1
+	}
+
+	fsys, walkRoot, displayPrefix, ok := walkTarget(rawPath, absPath, stat.IsDir(), isForced, section)
+	if !ok {
+		return nil, 0
+	}
+
+	return walkInputs(ctx, walkTargetArgs{
+		fsys:          fsys,
+		walkRoot:      walkRoot,
+		displayPrefix: displayPrefix,
+		absPath:       absPath,
+		rootIsDir:     stat.IsDir(),
+		isForced:      isForced,
+	}, rc), 0
+}
+
+func resolveURL(ctx context.Context, rawPath string, isForced, forceExpand bool, rc resolveContext) ([]lx.InputFile, int) {
+	section := rc.section
+
+	if (section.RunCfg.ExpandArchives || forceExpand) && lx.IsHTTPArchiveURL(rawPath) {
+		if !isForced && !lx.IsKept(rawPath, nil, section.Excludes) {
+			slog.Debug("Skipping URL archive due to exclude filter", "url", rawPath)
+			return nil, 0
+		}
+
+		tempPath, cleanup, err := lx.DownloadURLToTempFile(ctx, rawPath)
+		if err != nil {
+			slog.Error("Failed to download URL archive", "url", rawPath, "error", err)
+			return nil, 0
+		}
+		*rc.cleanups = append(*rc.cleanups, cleanup)
+
+		return expandArchive(ctx, tempPath, rawPath, isForced, rc, "Ignored in URL archive"), 0
+	}
+
+	if !isForced && !lx.IsKept(rawPath, section.Includes, section.Excludes) {
+		slog.Debug("Skipping URL due to filters", "url", rawPath)
+		return nil, 0
+	}
+
+	urlFile, err := lx.NewURLInputFile(rawPath)
+	if err != nil {
+		slog.Error("Failed to create URL input", "url", rawPath, "error", err)
+		return nil, 1
+	}
+	slog.Debug("URL accepted", "url", urlFile.Path)
+	return []lx.InputFile{urlFile}, 0
+}
+
+// walkTarget decides which filesystem to walk and how discovered paths should be
+// displayed, applying the filters that reject a path outright.
+func walkTarget(rawPath, absPath string, isDir, isForced bool, section Section) (fsys fs.FS, walkRoot, displayPrefix string, ok bool) {
+	if isDir {
+		return os.DirFS(absPath), ".", filepath.Clean(rawPath), true
+	}
+
+	isExpandableArchive := section.RunCfg.ExpandArchives && lx.IsArchivePath(rawPath)
+	if !isForced && !isExpandableArchive && !lx.IsKept(rawPath, section.Includes, section.Excludes) {
+		slog.Debug("Skipping file due to filters", "path", rawPath)
+		return nil, "", "", false
+	}
+	if !isForced && isExpandableArchive && !lx.IsKept(rawPath, nil, section.Excludes) {
+		slog.Debug("Skipping archive due to exclude filter", "path", rawPath)
+		return nil, "", "", false
+	}
+
+	rawPathClean := filepath.Clean(rawPath)
+	if !filepath.IsAbs(rawPathClean) && !strings.HasPrefix(rawPathClean, "..") {
+		return os.DirFS("."), filepath.ToSlash(rawPathClean), "", true
+	}
+	return os.DirFS(filepath.Dir(absPath)), filepath.Base(absPath), filepath.Dir(rawPathClean), true
+}
+
+type walkTargetArgs struct {
+	fsys          fs.FS
+	walkRoot      string
+	displayPrefix string
+	absPath       string
+	rootIsDir     bool
+	isForced      bool
+}
+
+func walkInputs(ctx context.Context, t walkTargetArgs, rc resolveContext) []lx.InputFile {
+	section := rc.section
+	includeSpecs := lx.CompileSpecs(section.Includes)
+
+	var baseRules, overrideRules []string
+	if !section.RunCfg.NoIgnore {
+		baseRules = append(baseRules, rc.ignoreRules...)
+	}
+	if !t.isForced {
+		overrideRules = append(overrideRules, section.Excludes...)
+	}
+
+	slog.Debug("Initializing Walker",
+		"walk_root", t.walkRoot,
+		"base_rules_count", len(baseRules),
+		"override_rules_count", len(overrideRules),
+		"is_forced", t.isForced,
+	)
+
+	walker := lx.NewWalker(baseRules, overrideRules)
+	walker.IgnoreEnabled = !section.RunCfg.NoIgnore
+	walker.SkipHidden = !section.RunCfg.ShowHidden && !t.isForced
+	walker.FollowDirSymlinks = section.RunCfg.FollowDirSymlinks
+	walker.SkipFileSymlinks = section.RunCfg.SkipFileSymlinks
+	if rc.debug {
+		walker.OnIgnore = func(p, reason string) {
+			slog.Debug("Ignored", "path", p, "reason", reason)
+		}
+	}
+
+	var files []lx.InputFile
+
+	err := walker.Walk(t.fsys, t.walkRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			slog.Warn("Error accessing path during walk", "path", path, "error", err)
+			return nil
+		}
+		if d.IsDir() {
+			if !t.isForced && len(includeSpecs) > 0 && path != "." && !lx.CouldMatchAnyDescendant(includeSpecs, path) {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		effectivePath := displayPath(path, t)
+
+		if section.RunCfg.ExpandArchives && lx.IsArchivePath(path) {
+			archiveAbsPath := t.absPath
+			if t.rootIsDir {
+				archiveAbsPath = filepath.Join(t.absPath, filepath.FromSlash(path))
+			}
+			files = append(files, expandArchive(ctx, archiveAbsPath, effectivePath, t.isForced, rc, "Ignored in archive")...)
+			return nil
+		}
+
+		if !t.isForced && len(includeSpecs) > 0 && !lx.IsMatchAnyCompiled(includeSpecs, path) {
+			slog.Debug("Ignored by include filter (-i)", "path", effectivePath)
+			return nil
+		}
+
+		if rc.outPath != "" {
+			if abs, _ := filepath.Abs(effectivePath); abs == rc.outPath {
+				slog.Warn("Skipping output file to avoid infinite recursion", "path", effectivePath)
+				return nil
+			}
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			slog.Error("Failed to stat file in walk", "path", path, "error", err)
+			return nil
+		}
+
+		f := lx.NewInputFile(t.fsys, path, info)
+		f.Path = effectivePath
+		f.AbsPath = inputAbsPath(path, t)
+
+		slog.Debug("File accepted by walker", "path", f.Path, "size", f.Size)
+		files = append(files, f)
+		return nil
+	})
+	if err != nil {
+		slog.Error("Walker traversal failed", "error", err)
+	}
+	slog.Debug("Walker finished", "root", t.walkRoot, "files_matched", len(files))
+
+	return files
+}
+
+func displayPath(path string, t walkTargetArgs) string {
+	if !t.rootIsDir {
+		if t.displayPrefix != "" {
+			return filepath.Join(t.displayPrefix, filepath.FromSlash(path))
+		}
+		return filepath.FromSlash(path)
+	}
+	if path == "." {
+		return t.displayPrefix
+	}
+	return filepath.Join(t.displayPrefix, filepath.FromSlash(path))
+}
+
+func inputAbsPath(path string, t walkTargetArgs) string {
+	if t.rootIsDir {
+		return filepath.Join(t.absPath, path)
+	}
+	if t.displayPrefix != "" {
+		return filepath.Join(filepath.Dir(t.absPath), path)
+	}
+	return t.absPath
+}
+
+func expandArchive(ctx context.Context, absPath, displayPath string, isForced bool, rc resolveContext, ignoreMsg string) []lx.InputFile {
+	archiveWalker := newArchiveWalker(rc.section.RunCfg.ShowHidden, isForced)
+	if rc.debug {
+		archiveWalker.OnIgnore = func(p, reason string) {
+			slog.Debug(ignoreMsg, "path", displayPath+"/"+p, "reason", reason)
+		}
+	}
+
+	includes := rc.section.Includes
+	if isForced {
+		includes = nil
+	}
+
+	collector := &fileCollector{}
+	if err := lx.ExpandArchive(ctx, absPath, displayPath, archiveWalker, includes, rc.outPath, collector); err != nil {
+		slog.Error("Failed to expand archive", "path", displayPath, "error", err)
+	}
+	return collector.files
+}

--- a/internal/cli/sections.go
+++ b/internal/cli/sections.go
@@ -16,6 +16,7 @@ type Section struct {
 
 	treeStrings map[int]string
 	skipFileOps map[int]bool
+	resolved    map[int][]lx.InputFile
 }
 
 func parseSections(ops []Op, defaultRunCfg lx.RunnerConfig) []Section {

--- a/internal/cli/size.go
+++ b/internal/cli/size.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/rasros/lx/pkg/lx"
 )
 
 // Multipliers are decimal to match the humanize template function, which
@@ -54,4 +56,11 @@ func parseSizeLimit(raw string) (int64, error) {
 	}
 
 	return n * mult, nil
+}
+
+// overMaxSize matches the guard streaming applies in AddFile, so a file dropped
+// from the bundle is dropped from the tree too. A negative size means unknown,
+// as for remote inputs, and is never over the limit.
+func overMaxSize(cfg lx.RunnerConfig, size int64) bool {
+	return cfg.MaxSize > 0 && size > cfg.MaxSize
 }

--- a/internal/cli/tree.go
+++ b/internal/cli/tree.go
@@ -1,25 +1,19 @@
 package cli
 
 import (
-	"context"
-	"io/fs"
-	"log/slog"
 	"net/url"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
-
-	"github.com/rasros/lx/pkg/lx"
 )
 
-func precomputeTrees(ctx context.Context, groups []Section, globalIgnoreRules []string) {
+func precomputeTrees(groups []Section) {
 	for i := range groups {
-		computeSectionTrees(ctx, &groups[i], globalIgnoreRules)
+		computeSectionTrees(&groups[i])
 	}
 }
 
-func computeSectionTrees(ctx context.Context, g *Section, globalIgnoreRules []string) {
+func computeSectionTrees(g *Section) {
 	var subFileIdxs []int
 	var subTreeIdxs []int
 	subTreeOnly := false
@@ -28,7 +22,12 @@ func computeSectionTrees(ctx context.Context, g *Section, globalIgnoreRules []st
 		if len(subTreeIdxs) > 0 && len(subFileIdxs) > 0 {
 			var paths []string
 			for _, idx := range subFileIdxs {
-				paths = append(paths, collectTreePaths(ctx, g.Ops[idx], g.RunCfg, g.Includes, g.Excludes, globalIgnoreRules)...)
+				for _, f := range g.resolved[idx] {
+					if overMaxSize(g.RunCfg, f.Size) {
+						continue
+					}
+					paths = append(paths, f.Path)
+				}
 			}
 			if len(paths) > 0 {
 				ts := buildASCIITree(paths)
@@ -70,171 +69,6 @@ func computeSectionTrees(ctx context.Context, g *Section, globalIgnoreRules []st
 		}
 	}
 	flush()
-}
-
-func collectTreePaths(ctx context.Context, op Op, runCfg lx.RunnerConfig, includes, excludes []string, globalIgnoreRules []string) []string {
-	var paths []string
-	includeSpecs := lx.CompileSpecs(includes)
-
-	rawPath := op.Value
-	isForced := op.Action == "file"
-
-	if rawPath == "-" {
-		return paths
-	}
-
-	if lx.IsHTTPURL(rawPath) {
-		if runCfg.ExpandArchives && lx.IsHTTPArchiveURL(rawPath) {
-			if !isForced && !lx.IsKept(rawPath, nil, excludes) {
-				return paths
-			}
-			archiveIncludes := includes
-			if isForced {
-				archiveIncludes = nil
-			}
-			return collectURLArchiveTreePaths(ctx, rawPath, runCfg.ShowHidden, isForced, archiveIncludes, runCfg.MaxSize)
-		}
-		if !isForced && !lx.IsKept(rawPath, includes, excludes) {
-			return paths
-		}
-		return append(paths, rawPath)
-	}
-
-	absPath, err := filepath.Abs(rawPath)
-	if err != nil {
-		return paths
-	}
-
-	stat, err := os.Stat(absPath)
-	if err != nil {
-		return paths
-	}
-
-	if !stat.IsDir() {
-		isExpandableArchive := runCfg.ExpandArchives && lx.IsArchivePath(rawPath)
-		if !isForced && !isExpandableArchive && !lx.IsKept(rawPath, includes, excludes) {
-			return paths
-		}
-		if !isForced && isExpandableArchive && !lx.IsKept(rawPath, nil, excludes) {
-			return paths
-		}
-
-		rawPathClean := filepath.Clean(rawPath)
-		effectivePath := filepath.ToSlash(rawPathClean)
-		if filepath.IsAbs(rawPathClean) {
-			effectivePath = filepath.ToSlash(absPath)
-		}
-
-		if isExpandableArchive {
-			archiveWalker := newArchiveWalker(runCfg.ShowHidden, isForced)
-			archiveIncludes := includes
-			if isForced {
-				archiveIncludes = nil
-			}
-			archivePaths, err := lx.ExpandArchivePaths(ctx, absPath, effectivePath, archiveWalker, archiveIncludes, runCfg.MaxSize)
-			if err != nil {
-				slog.Debug("Failed to expand archive for tree", "path", rawPath, "error", err)
-				return paths
-			}
-			return append(paths, archivePaths...)
-		}
-		if runCfg.MaxSize > 0 && stat.Size() > runCfg.MaxSize {
-			return paths
-		}
-		return append(paths, rawPathClean)
-	}
-
-	fsys := os.DirFS(absPath)
-	displayPrefix := filepath.Clean(rawPath)
-
-	var baseRules, overrideRules []string
-	if !runCfg.NoIgnore {
-		baseRules = append(baseRules, globalIgnoreRules...)
-	}
-	if !isForced {
-		overrideRules = append(overrideRules, excludes...)
-	}
-
-	w := lx.NewWalker(baseRules, overrideRules)
-	w.IgnoreEnabled = !runCfg.NoIgnore
-	w.SkipHidden = !runCfg.ShowHidden && !isForced
-	w.FollowDirSymlinks = runCfg.FollowDirSymlinks
-	w.SkipFileSymlinks = runCfg.SkipFileSymlinks
-
-	_ = w.Walk(fsys, ".", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil
-		}
-		if d.IsDir() {
-			if !isForced && len(includeSpecs) > 0 && path != "." && !lx.CouldMatchAnyDescendant(includeSpecs, path) {
-				return fs.SkipDir
-			}
-			return nil
-		}
-
-		var effectivePath string
-		if path == "." {
-			effectivePath = displayPrefix
-		} else if displayPrefix == "." {
-			effectivePath = filepath.FromSlash(path)
-		} else {
-			effectivePath = filepath.Join(displayPrefix, filepath.FromSlash(path))
-		}
-
-		if runCfg.ExpandArchives && lx.IsArchivePath(path) {
-			archiveAbsPath := filepath.Join(absPath, filepath.FromSlash(path))
-			archiveWalker := newArchiveWalker(runCfg.ShowHidden, isForced)
-			archiveIncludes := includes
-			if isForced {
-				archiveIncludes = nil
-			}
-			archivePaths, err := lx.ExpandArchivePaths(ctx, archiveAbsPath, effectivePath, archiveWalker, archiveIncludes, runCfg.MaxSize)
-			if err != nil {
-				slog.Debug("Failed to expand archive for tree", "path", effectivePath, "error", err)
-				return nil
-			}
-			paths = append(paths, archivePaths...)
-			return nil
-		}
-
-		if !isForced && len(includeSpecs) > 0 {
-			if !lx.IsMatchAnyCompiled(includeSpecs, path) {
-				return nil
-			}
-		}
-
-		if runCfg.MaxSize > 0 {
-			info, err := d.Info()
-			if err != nil {
-				return nil
-			}
-			if info.Size() > runCfg.MaxSize {
-				return nil
-			}
-		}
-
-		paths = append(paths, effectivePath)
-		return nil
-	})
-
-	return paths
-}
-
-func collectURLArchiveTreePaths(ctx context.Context, rawPath string, showHidden bool, isForced bool, includes []string, maxSize int64) []string {
-	tempPath, cleanup, err := lx.DownloadURLToTempFile(ctx, rawPath)
-	if err != nil {
-		slog.Debug("Failed to download URL archive for tree", "url", rawPath, "error", err)
-		return nil
-	}
-	defer cleanup()
-
-	archiveWalker := newArchiveWalker(showHidden, isForced)
-	paths, err := lx.ExpandArchivePaths(ctx, tempPath, rawPath, archiveWalker, includes, maxSize)
-	if err != nil {
-		slog.Debug("Failed to expand URL archive for tree", "url", rawPath, "error", err)
-		return nil
-	}
-	return paths
 }
 
 type treeNode struct {

--- a/internal/cli/tree_test.go
+++ b/internal/cli/tree_test.go
@@ -70,42 +70,72 @@ func TestBuildASCIITree_URLPreservesScheme(t *testing.T) {
 	}
 }
 
-func TestCollectTreePaths_StdinAndURLHandling(t *testing.T) {
-	ctx := context.Background()
-	runCfg := lx.RunnerConfig{}
+func testResolveContext(section Section) resolveContext {
+	var cleanups []func()
+	return resolveContext{section: section, cleanups: &cleanups}
+}
 
-	stdinPaths := collectTreePaths(ctx, Op{Action: "FILE", Value: "-", Type: CmdAction}, runCfg, nil, nil, nil)
-	if len(stdinPaths) != 0 {
-		t.Fatalf("stdin should not contribute paths, got: %v", stdinPaths)
+func resolvedPaths(files []lx.InputFile) []string {
+	paths := make([]string, 0, len(files))
+	for _, f := range files {
+		paths = append(paths, f.Path)
+	}
+	return paths
+}
+
+func TestResolveOp_StdinAndURLHandling(t *testing.T) {
+	ctx := context.Background()
+	rc := testResolveContext(Section{})
+
+	stdin, _ := resolveOp(ctx, Op{Action: "FILE", Value: "-", Type: CmdAction}, rc)
+	if len(stdin) != 0 {
+		t.Fatalf("stdin should not resolve to inputs, got: %v", resolvedPaths(stdin))
 	}
 
 	url := "https://example.com/repo.zip"
-	urlPaths := collectTreePaths(ctx, Op{Action: "FILE", Value: url, Type: CmdAction}, runCfg, nil, nil, nil)
-	if len(urlPaths) != 1 || urlPaths[0] != url {
-		t.Fatalf("url should be included as a file when not expanded, got: %v", urlPaths)
+	urls, _ := resolveOp(ctx, Op{Action: "FILE", Value: url, Type: CmdAction}, rc)
+	if got := resolvedPaths(urls); len(got) != 1 || got[0] != url {
+		t.Fatalf("url should resolve to one input, got: %v", got)
 	}
 }
 
-func TestCollectTreePaths_ExpandsLocalArchiveWithEntryIncludes(t *testing.T) {
+func TestResolveOp_ExpandsLocalArchiveWithEntryIncludes(t *testing.T) {
 	ctx := context.Background()
 	tmp := t.TempDir()
 	t.Chdir(tmp)
 
-	archivePath := filepath.Join(tmp, "archive.zip")
-	createTestZip(t, archivePath, map[string]string{
+	createTestZip(t, filepath.Join(tmp, "archive.zip"), map[string]string{
 		"hello.txt":       "hello\n",
 		"nested/world.go": "package nested\n",
 	})
 
-	paths := collectTreePaths(ctx, Op{Action: "FILE", Value: "archive.zip", Type: CmdAction}, lx.RunnerConfig{ExpandArchives: true}, []string{"*.go"}, nil, nil)
+	rc := testResolveContext(Section{
+		RunCfg:   lx.RunnerConfig{ExpandArchives: true},
+		Includes: []string{"*.go"},
+	})
+	files, _ := resolveOp(ctx, Op{Action: "FILE", Value: "archive.zip", Type: CmdAction}, rc)
+
 	want := []string{"archive.zip/nested/world.go"}
-	if !slices.Equal(paths, want) {
-		t.Fatalf("collectTreePaths archive include mismatch\nwant: %v\ngot:  %v", want, paths)
+	if got := resolvedPaths(files); !slices.Equal(got, want) {
+		t.Fatalf("archive include mismatch\nwant: %v\ngot:  %v", want, got)
+	}
+}
+
+// A missing path is reported so the stats summary can count it.
+func TestResolveOp_ReportsUnresolvedPaths(t *testing.T) {
+	t.Chdir(t.TempDir())
+	files, unresolved := resolveOp(context.Background(),
+		Op{Action: "FILE", Value: "nope.go", Type: CmdAction}, testResolveContext(Section{}))
+
+	if len(files) != 0 {
+		t.Errorf("got %v, want no inputs", resolvedPaths(files))
+	}
+	if unresolved != 1 {
+		t.Errorf("unresolved = %d, want 1", unresolved)
 	}
 }
 
 func TestPrecomputeTrees_TreeOnlyMarksFileOps(t *testing.T) {
-	ctx := context.Background()
 	groups := []Section{
 		{
 			Ops: []Op{
@@ -115,7 +145,7 @@ func TestPrecomputeTrees_TreeOnlyMarksFileOps(t *testing.T) {
 		},
 	}
 
-	precomputeTrees(ctx, groups, nil)
+	precomputeTrees(groups)
 	if !groups[0].skipFileOps[1] {
 		t.Fatalf("expected file op at index 1 to be skipped in tree-only section")
 	}

--- a/pkg/lx/core/config.go
+++ b/pkg/lx/core/config.go
@@ -1,5 +1,7 @@
 package core
 
+import "reflect"
+
 // NewConfig returns a default configuration.
 func NewConfig() *Config {
 	return &Config{
@@ -7,55 +9,15 @@ func NewConfig() *Config {
 	}
 }
 
-// Merge applies non-zero fields from src to dst.
+// Merge applies non-zero fields from src to dst. Every field is a string, so
+// "set" and "non-zero" coincide; a future non-string field whose zero value is
+// meaningful would need explicit handling.
 func Merge(dst *Config, src *Config) {
-	if src.FileContentTemplate != "" {
-		dst.FileContentTemplate = src.FileContentTemplate
-	}
-	if src.FileErrorTemplate != "" {
-		dst.FileErrorTemplate = src.FileErrorTemplate
-	}
-	if src.FileBinaryTemplate != "" {
-		dst.FileBinaryTemplate = src.FileBinaryTemplate
-	}
-	if src.FileCompactTemplate != "" {
-		dst.FileCompactTemplate = src.FileCompactTemplate
-	}
-	if src.FileHeaderTemplate != "" {
-		dst.FileHeaderTemplate = src.FileHeaderTemplate
-	}
-
-	if src.SectionTemplate != "" {
-		dst.SectionTemplate = src.SectionTemplate
-	}
-	if src.PromptTemplate != "" {
-		dst.PromptTemplate = src.PromptTemplate
-	}
-	if src.TreeTemplate != "" {
-		dst.TreeTemplate = src.TreeTemplate
-	}
-	if src.MetaTemplate != "" {
-		dst.MetaTemplate = src.MetaTemplate
-	}
-
-	if src.SectionHeaderTemplate != "" {
-		dst.SectionHeaderTemplate = src.SectionHeaderTemplate
-	}
-	if src.SectionFooterTemplate != "" {
-		dst.SectionFooterTemplate = src.SectionFooterTemplate
-	}
-
-	if src.OutputHeaderTemplate != "" {
-		dst.OutputHeaderTemplate = src.OutputHeaderTemplate
-	}
-	if src.OutputFooterTemplate != "" {
-		dst.OutputFooterTemplate = src.OutputFooterTemplate
-	}
-	if src.StatsTemplate != "" {
-		dst.StatsTemplate = src.StatsTemplate
-	}
-
-	if src.OutputFormat != "" {
-		dst.OutputFormat = src.OutputFormat
+	d := reflect.ValueOf(dst).Elem()
+	s := reflect.ValueOf(src).Elem()
+	for i := 0; i < s.NumField(); i++ {
+		if f := s.Field(i); !f.IsZero() {
+			d.Field(i).Set(f)
+		}
 	}
 }

--- a/pkg/lx/core/token.go
+++ b/pkg/lx/core/token.go
@@ -16,92 +16,50 @@ const (
 func DefaultTokenCounter(size int64, content interface{}) int64 {
 	switch v := content.(type) {
 	case string:
-		return estimateString(v, size)
+		return estimate(v, size)
 	case []byte:
-		return estimateBytes(v, size)
+		return estimate(v, size)
 	case fmt.Stringer:
-		return estimateString(v.String(), size)
+		return estimate(v.String(), size)
 	}
 	return size / 4
 }
 
-func estimateString(s string, size int64) int64 {
-	n := int64(len(s))
+// byteseq is the pair of representations content arrives in. Scanning them with
+// one implementation keeps the two from drifting apart.
+type byteseq interface {
+	~string | ~[]byte
+}
+
+// estimate scans the whole content when it is small enough, and otherwise
+// extrapolates from a head and tail sample.
+func estimate[T byteseq](d T, size int64) int64 {
+	n := int64(len(d))
 	if n == 0 {
 		return size / 4
 	}
 	if n <= sampleThreshold {
-		return scanString(s)
+		return scan(d)
 	}
+
 	headEnd := sampleHead
-	tailStart := len(s) - sampleTail
+	tailStart := len(d) - sampleTail
 	if tailStart < headEnd {
-		return scanString(s)
+		return scan(d)
 	}
-	sampleTokens := scanString(s[:headEnd]) + scanString(s[tailStart:])
+
+	sampleTokens := scan(d[:headEnd]) + scan(d[tailStart:])
 	sampleBytes := int64(headEnd + sampleTail)
 	return sampleTokens * n / sampleBytes
 }
 
-func estimateBytes(b []byte, size int64) int64 {
-	n := int64(len(b))
-	if n == 0 {
-		return size / 4
-	}
-	if n <= sampleThreshold {
-		return scanBytes(b)
-	}
-	headEnd := sampleHead
-	tailStart := len(b) - sampleTail
-	if tailStart < headEnd {
-		return scanBytes(b)
-	}
-	sampleTokens := scanBytes(b[:headEnd]) + scanBytes(b[tailStart:])
-	sampleBytes := int64(headEnd + sampleTail)
-	return sampleTokens * n / sampleBytes
-}
-
-func scanString(s string) int64 {
+func scan[T byteseq](d T) int64 {
 	var (
 		wordRuns, wordChars, symbols, wsRuns, newlines, nonAscii int64
 		inWord, inWS                                             bool
 	)
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		switch {
-		case c >= 0x80:
-			nonAscii++
-			inWord, inWS = false, false
-		case isWord(c):
-			if !inWord {
-				wordRuns++
-				inWord = true
-			}
-			wordChars++
-			inWS = false
-		case c == '\n':
-			newlines++
-			inWord, inWS = false, false
-		case isWS(c):
-			if !inWS {
-				wsRuns++
-				inWS = true
-			}
-			inWord = false
-		default:
-			symbols++
-			inWord, inWS = false, false
-		}
-	}
-	return combine(wordRuns, wordChars, symbols, wsRuns, newlines, nonAscii)
-}
-
-func scanBytes(b []byte) int64 {
-	var (
-		wordRuns, wordChars, symbols, wsRuns, newlines, nonAscii int64
-		inWord, inWS                                             bool
-	)
-	for _, c := range b {
+	for i := 0; i < len(d); i++ {
+		c := d[i]
 		switch {
 		case c >= 0x80:
 			nonAscii++

--- a/pkg/lx/core/token_test.go
+++ b/pkg/lx/core/token_test.go
@@ -104,7 +104,7 @@ func TestDefaultTokenCounter_LargeContentSampling(t *testing.T) {
 
 	// Same content scanned without sampling: feed it as a slice that's exactly
 	// the content but invoke the inner scanner directly via a sub-threshold split.
-	exact := scanString(full)
+	exact := scan(full)
 
 	diff := sampled - exact
 	if diff < 0 {
@@ -161,5 +161,27 @@ func TestDefaultTokenCounter_DensityFollowsSymbolShare(t *testing.T) {
 	}
 	if jsonWords >= prose {
 		t.Errorf("JSON of long string values (%.2f) should still beat prose (%.2f)", jsonWords, prose)
+	}
+}
+
+// The two representations shared duplicated scanners before; this pins that one
+// implementation now serves both.
+func TestDefaultTokenCounterAgreesAcrossRepresentations(t *testing.T) {
+	samples := []string{
+		"",
+		"hello world",
+		strings.Repeat(`{"a":1,"b":[true,false]},`, 40),
+		strings.Repeat("func Alpha() int {\n\treturn 1\n}\n", 40),
+		strings.Repeat("naïve café — résumé ", 40),
+		strings.Repeat("x", sampleThreshold+sampleHead+sampleTail+1),
+	}
+
+	for i, s := range samples {
+		size := int64(len(s))
+		fromString := DefaultTokenCounter(size, s)
+		fromBytes := DefaultTokenCounter(size, []byte(s))
+		if fromString != fromBytes {
+			t.Errorf("sample %d: string gave %d, []byte gave %d", i, fromString, fromBytes)
+		}
 	}
 }

--- a/pkg/lx/core/types.go
+++ b/pkg/lx/core/types.go
@@ -63,27 +63,29 @@ type TemplateEngine struct {
 	UseSeparators bool
 }
 
-// Config represents the core library configuration.
+// Config represents the core library configuration. The yaml tags are the
+// documented config-file keys, so this struct is the single definition of that
+// schema.
 type Config struct {
-	FileContentTemplate string
-	FileErrorTemplate   string
-	FileBinaryTemplate  string
-	FileCompactTemplate string
-	FileHeaderTemplate  string
+	FileContentTemplate string `yaml:"file_content_template"`
+	FileErrorTemplate   string `yaml:"file_error_template"`
+	FileBinaryTemplate  string `yaml:"file_binary_template"`
+	FileCompactTemplate string `yaml:"file_compact_template"`
+	FileHeaderTemplate  string `yaml:"file_header_template"`
 
-	SectionTemplate string
-	PromptTemplate  string
-	TreeTemplate    string
-	MetaTemplate    string
+	SectionTemplate string `yaml:"section_template"`
+	PromptTemplate  string `yaml:"prompt_template"`
+	TreeTemplate    string `yaml:"tree_template"`
+	MetaTemplate    string `yaml:"meta_template"`
 
-	SectionHeaderTemplate string
-	SectionFooterTemplate string
+	SectionHeaderTemplate string `yaml:"section_header_template"`
+	SectionFooterTemplate string `yaml:"section_footer_template"`
 
-	OutputHeaderTemplate string
-	OutputFooterTemplate string
-	StatsTemplate        string
+	OutputHeaderTemplate string `yaml:"output_header_template"`
+	OutputFooterTemplate string `yaml:"output_footer_template"`
+	StatsTemplate        string `yaml:"stats_template"`
 
-	OutputFormat string
+	OutputFormat string `yaml:"output_format"`
 }
 
 // FileContext represents the data provided to file-level templates.

--- a/pkg/lx/facade.go
+++ b/pkg/lx/facade.go
@@ -24,6 +24,7 @@ type Walker = walkerpkg.Walker
 type CompiledSpec = walkerpkg.CompiledSpec
 
 type FileErrorHandler = streamingpkg.FileErrorHandler
+type FileSink = sources.FileSink
 
 func NewConfig() *Config { return core.NewConfig() }
 
@@ -127,14 +128,9 @@ func (s *Stream) Execute(ctx context.Context, w io.Writer) error { return s.inne
 
 func (s *Stream) GetEngine() *TemplateEngine { return s.inner.GetEngine() }
 
-type streamSink struct{ s *Stream }
+// Add lets a Stream be used directly as a FileSink.
+func (s *Stream) Add(f InputFile) { s.AddFile(f) }
 
-func (ss streamSink) Add(f InputFile) { ss.s.AddFile(f) }
-
-func ExpandArchive(ctx context.Context, absPath, displayPath string, walker *Walker, includes []string, outPath string, stream *Stream) error {
-	return sources.ExpandArchive(ctx, absPath, displayPath, walker, includes, outPath, streamSink{s: stream})
-}
-
-func ExpandArchivePaths(ctx context.Context, absPath, displayPath string, walker *Walker, includes []string, maxSize int64) ([]string, error) {
-	return sources.ExpandArchivePaths(ctx, absPath, displayPath, walker, includes, maxSize)
+func ExpandArchive(ctx context.Context, absPath, displayPath string, walker *Walker, includes []string, outPath string, sink FileSink) error {
+	return sources.ExpandArchive(ctx, absPath, displayPath, walker, includes, outPath, sink)
 }

--- a/pkg/lx/facade.go
+++ b/pkg/lx/facade.go
@@ -27,6 +27,8 @@ type FileErrorHandler = streamingpkg.FileErrorHandler
 
 func NewConfig() *Config { return core.NewConfig() }
 
+func Merge(dst *Config, src *Config) { core.Merge(dst, src) }
+
 func NewWalker(basePatterns, overridePatterns []string) *Walker {
 	return walkerpkg.NewWalker(basePatterns, overridePatterns)
 }

--- a/pkg/lx/sources/archive.go
+++ b/pkg/lx/sources/archive.go
@@ -42,29 +42,6 @@ type FileSink interface {
 	Add(InputFile)
 }
 
-// ExpandArchivePaths lists archive entry paths. Entries larger than maxSize are
-// omitted; a maxSize of zero or less disables the limit.
-func ExpandArchivePaths(ctx context.Context, absPath, displayPath string, w *walker.Walker, includes []string, maxSize int64) ([]string, error) {
-	var paths []string
-	sink := &pathCollectorSink{out: &paths, maxSize: maxSize}
-	if err := ExpandArchive(ctx, absPath, displayPath, w, includes, "", sink); err != nil {
-		return nil, err
-	}
-	return paths, nil
-}
-
-type pathCollectorSink struct {
-	out     *[]string
-	maxSize int64
-}
-
-func (s *pathCollectorSink) Add(f InputFile) {
-	if s.maxSize > 0 && f.Size > s.maxSize {
-		return
-	}
-	*s.out = append(*s.out, f.Path)
-}
-
 type archiveCandidate struct {
 	key           string
 	entryPath     string


### PR DESCRIPTION
The content pass and collectTreePaths each implemented the same discovery decisions, and had already drifted twice — both symlink bugs came from that.

Discovery now happens once in resolve.go. Each file op resolves to a list of InputFile values that the tree builder and content pass both consume. collectTreePaths is gone, along with ExpandArchivePaths which existed only to serve it. ExpandArchive takes a FileSink now, which Stream satisfies directly. The size guard moves behind one shared predicate.

Output-neutral: no golden file moved, and tree, include-filtered and archive runs are byte-identical against a binary built from main.