### PR TITLE
feat: convert html to markdown under -D

### DIFF
--- a/cmd/lx/golden_core_test.go
+++ b/cmd/lx/golden_core_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -193,7 +195,19 @@ func TestGoldenArchive(t *testing.T) {
 		{name: "118_expand_archive_tar_bz2", args: []string{"-Z", "archive.tar.bz2"}},
 		{name: "119_expand_archive_tar", args: []string{"-Z", "archive.tar"}},
 		{name: "119b_archive_image_html", args: []string{"--html", "-Z", "images.zip"}},
+		{name: "119c_archive_html_converted", args: []string{"-Z", "-D", "docs.zip"}},
 	})
+}
+
+func TestGoldenDocumentURLMediaType(t *testing.T) {
+	dir := setupDocumentsFixture(t)
+	server := httptest.NewServer(http.FileServer(http.Dir(dir)))
+	defer server.Close()
+
+	runTestGolden(t, dir, []goldenTestCase{
+		{name: "139e_url_html_by_media_type", args: []string{"-D", server.URL + "/suffixless"}},
+		{name: "139f_url_html_no_extract_flag", args: []string{server.URL + "/suffixless"}},
+	}, server.URL)
 }
 
 func TestGoldenDocuments(t *testing.T) {
@@ -214,5 +228,13 @@ func TestGoldenDocuments(t *testing.T) {
 		{name: "132_docs_xlsx_head", args: []string{"-D", "--head", "2", "sample.xlsx"}},
 		{name: "133_docs_pptx_lines", args: []string{"-D", "--lines", "3", "sample.pptx"}},
 		{name: "134_docs_pdf_xml", args: []string{"--xml", "-D", "sample.pdf"}},
+		{name: "135_docs_html_markdown", args: []string{"-D", "sample.html"}},
+		{name: "136_docs_html_no_extract_flag", args: []string{"sample.html"}},
+		{name: "137_docs_html_xml", args: []string{"--xml", "-D", "sample.html"}},
+		{name: "138_docs_html_head", args: []string{"-D", "--head", "6", "sample.html"}},
+		{name: "139_docs_htm_extension", args: []string{"-D", "sample.htm"}},
+		{name: "139b_docs_xhtml_extension", args: []string{"-D", "sample.xhtml"}},
+		{name: "139c_docs_html_line_numbers", args: []string{"-D", "-l", "sample.html"}},
+		{name: "139d_docs_html_into_html_output", args: []string{"--html", "-D", "sample.html"}},
 	})
 }

--- a/cmd/lx/goldenfixtures/archive.go
+++ b/cmd/lx/goldenfixtures/archive.go
@@ -30,6 +30,10 @@ func SetupArchiveFixture(t *testing.T) string {
 		{"hello.txt", "Hello from tar bz2!\n"},
 		{"nested/world.go", "package nested\n"},
 	})
+	createTestZip(filepath.Join(dir, "docs.zip"), [][2]string{
+		{"guide.html", "<h1>Guide</h1><p>Inside an archive.</p>"},
+		{"notes.txt", "plain\n"},
+	})
 	createTestGz(filepath.Join(dir, "notes.txt.gz"), "compressed on its own\nsecond line\n")
 	createTestZip(filepath.Join(dir, "images.zip"), [][2]string{
 		{"logo.png", "\x89PNG\r\n\x1a\n\x00\x00\x00\x0D"},
@@ -47,6 +51,11 @@ func SetupDocumentsFixture(t *testing.T) string {
 	t.Helper()
 	setupMockConfig(t)
 	dir := t.TempDir()
+
+	writeFile(t, dir, "sample.html", htmlFixture, 0644)
+	writeFile(t, dir, "sample.htm", "<h1>Legacy</h1><p>htm extension</p>", 0644)
+	writeFile(t, dir, "sample.xhtml", "<h1>Strict</h1><p>xhtml extension</p>", 0644)
+	writeFile(t, dir, "suffixless", htmlFixture, 0644)
 
 	fixtures := []string{
 		"sample.pdf", "sample.docx", "sample.xlsx",
@@ -177,3 +186,27 @@ func createTestZip(path string, files [][2]string) {
 		}
 	}
 }
+
+const htmlFixture = `<!doctype html>
+<html><head><title>API Reference</title>
+<style>body { color: red }</style>
+<script>var tracked = 1;</script>
+</head>
+<body>
+<nav><a href="/">Home</a></nav>
+<h1>Authentication</h1>
+<p>All endpoints require a <code>Bearer</code> token. See <a href="/auth">auth docs</a>.</p>
+<hr>
+<h2>Example</h2>
+<pre><code class="language-go">func main() {
+	fmt.Println("hi")
+}</code></pre>
+<ul><li>First</li><li>Second<ul><li>Nested</li></ul></li></ul>
+<blockquote><p>Rate limits apply.</p></blockquote>
+<table><thead><tr><th>Field</th><th>Type</th></tr></thead>
+<tbody><tr><td>id</td><td>int</td></tr></tbody></table>
+<p><img src="data:image/png;base64,AAAABBBBCCCC" alt="inline blob"></p>
+<p><img src="/logo.png" alt="Logo"></p>
+<footer>Copyright 2026</footer>
+</body></html>
+`

--- a/cmd/lx/testdata/golden/119c_archive_html_converted.golden
+++ b/cmd/lx/testdata/golden/119c_archive_html_converted.golden
@@ -1,0 +1,17 @@
+--- STDOUT ---
+[1/2] docs.zip/guide.html (3 rows)
+---
+```markdown
+# Guide
+
+Inside an archive.
+```
+
+[2/2] docs.zip/notes.txt (1 rows)
+---
+```text
+plain
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/135_docs_html_markdown.golden
+++ b/cmd/lx/testdata/golden/135_docs_html_markdown.golden
@@ -1,0 +1,35 @@
+--- STDOUT ---
+sample.html (27 rows)
+---
+```markdown
+# Authentication
+
+All endpoints require a `Bearer` token. See [auth docs](/auth).
+
+---
+
+## Example
+
+```go
+func main() {
+	fmt.Println("hi")
+}
+```
+
+- First
+- Second
+  - Nested
+
+> Rate limits apply.
+
+| Field | Type |
+|---|---|
+| id | int |
+
+![inline blob]
+
+![Logo](/logo.png)
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/136_docs_html_no_extract_flag.golden
+++ b/cmd/lx/testdata/golden/136_docs_html_no_extract_flag.golden
@@ -1,0 +1,30 @@
+--- STDOUT ---
+sample.html (22 rows)
+---
+```html
+<!doctype html>
+<html><head><title>API Reference</title>
+<style>body { color: red }</style>
+<script>var tracked = 1;</script>
+</head>
+<body>
+<nav><a href="/">Home</a></nav>
+<h1>Authentication</h1>
+<p>All endpoints require a <code>Bearer</code> token. See <a href="/auth">auth docs</a>.</p>
+<hr>
+<h2>Example</h2>
+<pre><code class="language-go">func main() {
+	fmt.Println("hi")
+}</code></pre>
+<ul><li>First</li><li>Second<ul><li>Nested</li></ul></li></ul>
+<blockquote><p>Rate limits apply.</p></blockquote>
+<table><thead><tr><th>Field</th><th>Type</th></tr></thead>
+<tbody><tr><td>id</td><td>int</td></tr></tbody></table>
+<p><img src="data:image/png;base64,AAAABBBBCCCC" alt="inline blob"></p>
+<p><img src="/logo.png" alt="Logo"></p>
+<footer>Copyright 2026</footer>
+</body></html>
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/137_docs_html_xml.golden
+++ b/cmd/lx/testdata/golden/137_docs_html_xml.golden
@@ -1,0 +1,38 @@
+--- STDOUT ---
+<content>
+  <document index="1" language="markdown" rows="27">
+    <source>sample.html</source>
+    <document_content>
+# Authentication
+
+All endpoints require a `Bearer` token. See [auth docs](/auth).
+
+---
+
+## Example
+
+```go
+func main() {
+	fmt.Println("hi")
+}
+```
+
+- First
+- Second
+  - Nested
+
+> Rate limits apply.
+
+| Field | Type |
+|---|---|
+| id | int |
+
+![inline blob]
+
+![Logo](/logo.png)
+    </document_content>
+  </document>
+</content>
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/138_docs_html_head.golden
+++ b/cmd/lx/testdata/golden/138_docs_html_head.golden
@@ -1,0 +1,14 @@
+--- STDOUT ---
+sample.html (27 rows)
+---
+```markdown
+# Authentication
+
+All endpoints require a `Bearer` token. See [auth docs](/auth).
+
+---
+
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/139_docs_htm_extension.golden
+++ b/cmd/lx/testdata/golden/139_docs_htm_extension.golden
@@ -1,0 +1,11 @@
+--- STDOUT ---
+sample.htm (3 rows)
+---
+```markdown
+# Legacy
+
+htm extension
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/139b_docs_xhtml_extension.golden
+++ b/cmd/lx/testdata/golden/139b_docs_xhtml_extension.golden
@@ -1,0 +1,11 @@
+--- STDOUT ---
+sample.xhtml (3 rows)
+---
+```markdown
+# Strict
+
+xhtml extension
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/139c_docs_html_line_numbers.golden
+++ b/cmd/lx/testdata/golden/139c_docs_html_line_numbers.golden
@@ -1,0 +1,35 @@
+--- STDOUT ---
+sample.html (27 rows)
+---
+```markdown
+ 1: # Authentication
+ 2: 
+ 3: All endpoints require a `Bearer` token. See [auth docs](/auth).
+ 4: 
+ 5: ---
+ 6: 
+ 7: ## Example
+ 8: 
+ 9: ```go
+10: func main() {
+11: 	fmt.Println("hi")
+12: }
+13: ```
+14: 
+15: - First
+16: - Second
+17:   - Nested
+18: 
+19: > Rate limits apply.
+20: 
+21: | Field | Type |
+22: |---|---|
+23: | id | int |
+24: 
+25: ![inline blob]
+26: 
+27: ![Logo](/logo.png)
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/139d_docs_html_into_html_output.golden
+++ b/cmd/lx/testdata/golden/139d_docs_html_into_html_output.golden
@@ -1,0 +1,90 @@
+--- STDOUT ---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>lx Output</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.classless.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" media="(prefers-color-scheme: light)">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" media="(prefers-color-scheme: dark)">
+<style>
+.hljs { background: transparent !important; }
+img { max-width: 100%; height: auto; }
+pre { background-color: transparent; border: none; }
+article > header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background-color: var(--pico-card-background-color); 
+  border-bottom: 1px solid var(--pico-muted-border-color);
+}
+.file-anchor {
+  text-decoration: none;
+  color: var(--pico-muted-color);
+  margin-right: 0.5rem;
+  font-weight: bold;
+  border: none;
+}
+.file-anchor:hover {
+  color: var(--pico-primary);
+  text-decoration: underline;
+}
+.error-state { color: var(--pico-color-red-500); font-weight: bold; }
+</style>
+</head>
+<body>
+<header>
+<hgroup>
+<h1>lx output</h1>
+<p>
+  Files: 1 &bull; 
+  Size: 779 B &bull; 
+  Path: .
+</p>
+</hgroup>
+</header>
+<main>
+<article id="file-1">
+<header>
+ <a href="#file-1" aria-label="Link to this file"><strong>sample.html</strong></a>
+ <small>(27 rows)</small>
+</header>
+<pre><code class="language-markdown">
+# Authentication
+
+All endpoints require a `Bearer` token. See [auth docs](/auth).
+
+---
+
+## Example
+
+```go
+func main() {
+	fmt.Println(&#34;hi&#34;)
+}
+```
+
+- First
+- Second
+  - Nested
+
+&gt; Rate limits apply.
+
+| Field | Type |
+|---|---|
+| id | int |
+
+![inline blob]
+
+![Logo](/logo.png)
+</code></pre>
+</article>
+</section></main>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+<script>hljs.highlightAll();</script>
+</body>
+</html>
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/139e_url_html_by_media_type.golden
+++ b/cmd/lx/testdata/golden/139e_url_html_by_media_type.golden
@@ -1,0 +1,35 @@
+--- STDOUT ---
+/ROOT/suffixless (27 rows)
+---
+```markdown
+# Authentication
+
+All endpoints require a `Bearer` token. See [auth docs](/auth).
+
+---
+
+## Example
+
+```go
+func main() {
+	fmt.Println("hi")
+}
+```
+
+- First
+- Second
+  - Nested
+
+> Rate limits apply.
+
+| Field | Type |
+|---|---|
+| id | int |
+
+![inline blob]
+
+![Logo](/logo.png)
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/139f_url_html_no_extract_flag.golden
+++ b/cmd/lx/testdata/golden/139f_url_html_no_extract_flag.golden
@@ -1,0 +1,30 @@
+--- STDOUT ---
+/ROOT/suffixless (22 rows)
+---
+```
+<!doctype html>
+<html><head><title>API Reference</title>
+<style>body { color: red }</style>
+<script>var tracked = 1;</script>
+</head>
+<body>
+<nav><a href="/">Home</a></nav>
+<h1>Authentication</h1>
+<p>All endpoints require a <code>Bearer</code> token. See <a href="/auth">auth docs</a>.</p>
+<hr>
+<h2>Example</h2>
+<pre><code class="language-go">func main() {
+	fmt.Println("hi")
+}</code></pre>
+<ul><li>First</li><li>Second<ul><li>Nested</li></ul></li></ul>
+<blockquote><p>Rate limits apply.</p></blockquote>
+<table><thead><tr><th>Field</th><th>Type</th></tr></thead>
+<tbody><tr><td>id</td><td>int</td></tr></tbody></table>
+<p><img src="data:image/png;base64,AAAABBBBCCCC" alt="inline blob"></p>
+<p><img src="/logo.png" alt="Logo"></p>
+<footer>Copyright 2026</footer>
+</body></html>
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/185_help_long.golden
+++ b/cmd/lx/testdata/golden/185_help_long.golden
@@ -245,14 +245,30 @@
           Inputs whose size is not known ahead of time, such as remote URLs, are
           never skipped.
   [1m-D, --documents[22m
-          Extract plain text from document files for the next section.
+          Convert document files to text for the next section.
           
           By default, document files are treated as binary. When set, the
-          following formats are converted to plain text instead:
+          following formats are converted instead:
             - .pdf - via PDF text extraction
             - .docx - via Word document parsing
             - .xlsx - via spreadsheet cell values (one sheet per section)
             - .pptx - via presentation text extraction
+            - .html, .htm, .xhtml - to structural Markdown
+          
+          HTML is the one format whose structure survives, because it is present
+          in the input: headings become #, horizontal rules become ---, and
+          lists, blockquotes, tables, links and fenced code blocks are
+          preserved, with the code language taken from a highlight.js or prism
+          class when present. Scripts, styles, navigation, headers, footers and
+          asides are dropped, as are data: URIs, which is where the base64
+          payloads that bloat a bundle live.
+          
+          Inline emphasis is deliberately not converted: it carries little
+          signal for a model, and keeping it would mean escaping every literal *
+          and _ in body text.
+          
+          The other formats yield plain text, which is as much as their
+          extraction libraries expose.
   [1m-Z, --expand[22m
           Expand archive files inline for subsequent file arguments.
           

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/nguyenthenguyen/docx v0.0.0-20230621112118-9c8e795a11db
 	github.com/odvcencio/gotreesitter v0.20.8
 	github.com/xuri/excelize/v2 v2.10.1
+	golang.org/x/net v0.56.0
 )
 
 require (
@@ -40,6 +41,5 @@ require (
 	github.com/xuri/nfp v0.0.2-0.20250530014748-2ddeb826f9a9 // indirect
 	go4.org v0.0.0-20260112195520-a5071408f32f // indirect
 	golang.org/x/crypto v0.53.0 // indirect
-	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 )

--- a/internal/cli/defs.go
+++ b/internal/cli/defs.go
@@ -246,14 +246,28 @@ size is not known ahead of time, such as remote URLs, are never skipped.`,
 		Type:      CmdInterleaved,
 		ValueType: ValueNone,
 		Usage:     "Extract text from document files for subsequent paths",
-		Long: `Extract plain text from document files for the next section.
+		Long: `Convert document files to text for the next section.
 
 By default, document files are treated as binary. When set, the following
-formats are converted to plain text instead:
-  - .pdf  - via PDF text extraction
-  - .docx - via Word document parsing
-  - .xlsx - via spreadsheet cell values (one sheet per section)
-  - .pptx - via presentation text extraction`,
+formats are converted instead:
+  - .pdf   - via PDF text extraction
+  - .docx  - via Word document parsing
+  - .xlsx  - via spreadsheet cell values (one sheet per section)
+  - .pptx  - via presentation text extraction
+  - .html, .htm, .xhtml - to structural Markdown
+
+HTML is the one format whose structure survives, because it is present in the
+input: headings become #, horizontal rules become ---, and lists, blockquotes,
+tables, links and fenced code blocks are preserved, with the code language taken
+from a highlight.js or prism class when present. Scripts, styles, navigation,
+headers, footers and asides are dropped, as are data: URIs, which is where the
+base64 payloads that bloat a bundle live.
+
+Inline emphasis is deliberately not converted: it carries little signal for a
+model, and keeping it would mean escaping every literal * and _ in body text.
+
+The other formats yield plain text, which is as much as their extraction
+libraries expose.`,
 	},
 	{
 		Category:  CatInterleaved,

--- a/pkg/lx/doc.go
+++ b/pkg/lx/doc.go
@@ -22,7 +22,8 @@
 //   - LineNumbers enables numbered output.
 //   - SkeletonFunctions / SkeletonTypes reduce source files to signatures/defs.
 //   - ExpandArchives opens compressed files and directories for .zip/.tar.gz, etc..
-//   - ExtractDocuments enables text extraction for .pdf/.docx/.xlsx/.pptx.
+//   - ExtractDocuments converts .pdf/.docx/.xlsx/.pptx to text and HTML to
+//     Markdown.
 //   - ShowHidden, FollowDirSymlinks, SkipFileSymlinks control discovery options.
 //   - NoIgnore disables adhering to .ignore files.
 //
@@ -42,7 +43,8 @@
 // Archive and document helpers:
 //
 //   - IsArchivePath / ExpandArchive handle archive expansion into stream files.
-//   - IsDocumentPath / ExtractDocumentText handle document text extraction.
+//   - IsDocumentPath / ConvertInput convert documents to text, or to Markdown
+//     for HTML.
 //
 // Typical flow:
 //

--- a/pkg/lx/internal/html.go
+++ b/pkg/lx/internal/html.go
@@ -1,0 +1,377 @@
+package internal
+
+import (
+	"io"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
+)
+
+// Inline elements join the surrounding paragraph instead of starting one.
+var htmlInline = map[atom.Atom]bool{
+	atom.A: true, atom.Img: true, atom.Code: true, atom.Span: true,
+	atom.Strong: true, atom.B: true, atom.Em: true, atom.I: true,
+	atom.Small: true, atom.Abbr: true, atom.Cite: true, atom.Kbd: true,
+	atom.Samp: true, atom.Var: true, atom.Sub: true, atom.Sup: true,
+	atom.Time: true, atom.Q: true, atom.S: true, atom.Del: true,
+	atom.Ins: true, atom.Mark: true, atom.U: true, atom.Label: true,
+}
+
+var htmlDropped = map[atom.Atom]bool{
+	atom.Script:   true,
+	atom.Style:    true,
+	atom.Noscript: true,
+	atom.Nav:      true,
+	atom.Header:   true,
+	atom.Footer:   true,
+	atom.Aside:    true,
+	atom.Template: true,
+	atom.Svg:      true,
+	atom.Head:     true,
+}
+
+// HTMLToMarkdown converts a document to structural Markdown: headings, rules,
+// lists, blockquotes, fenced code, tables, links and images. Only the body is
+// rendered; the title is page metadata rather than content.
+//
+// Inline emphasis is deliberately dropped: keeping it would mean escaping every
+// literal * and _ in body text, for a signal a model barely uses.
+func HTMLToMarkdown(r io.Reader) ([]byte, error) {
+	doc, err := html.Parse(r)
+	if err != nil {
+		return nil, err
+	}
+
+	w := &markdownWriter{}
+	root := htmlBody(doc)
+	if root == nil {
+		root = doc
+	}
+	w.walk(root)
+
+	return []byte(w.result()), nil
+}
+
+type markdownWriter struct {
+	blocks  []string
+	pending strings.Builder
+}
+
+func (w *markdownWriter) block(s string) {
+	w.flush()
+	if s = strings.Trim(s, "\n"); s != "" {
+		w.blocks = append(w.blocks, s)
+	}
+}
+
+func (w *markdownWriter) flush() {
+	if text := collapseSpace(w.pending.String()); text != "" {
+		w.blocks = append(w.blocks, text)
+	}
+	w.pending.Reset()
+}
+
+func (w *markdownWriter) result() string {
+	w.flush()
+	return strings.Join(w.blocks, "\n\n") + "\n"
+}
+
+func (w *markdownWriter) walk(n *html.Node) {
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		switch c.Type {
+		case html.TextNode:
+			w.pending.WriteString(c.Data)
+
+		case html.ElementNode:
+			if htmlDropped[c.DataAtom] {
+				continue
+			}
+			switch c.DataAtom {
+			case atom.H1, atom.H2, atom.H3, atom.H4, atom.H5, atom.H6:
+				level, _ := strconv.Atoi(strings.TrimPrefix(c.Data, "h"))
+				if level < 1 || level > 6 {
+					level = 1
+				}
+				w.block(strings.Repeat("#", level) + " " + inlineText(c))
+			case atom.Hr:
+				w.block("---")
+			case atom.P:
+				w.block(inlineText(c))
+			case atom.Pre:
+				w.block(codeFence(c))
+			case atom.Ul, atom.Ol:
+				w.block(renderList(c, 0))
+			case atom.Blockquote:
+				w.block(prefixLines(subdocument(c), "> "))
+			case atom.Table:
+				w.block(renderTable(c))
+			case atom.Dt:
+				w.block(inlineText(c))
+			case atom.Dd:
+				w.block(inlineText(c))
+			case atom.Br:
+				w.pending.WriteString("\n")
+			default:
+				if htmlInline[c.DataAtom] {
+					writeInlineNode(&w.pending, c)
+					continue
+				}
+				w.walk(c)
+			}
+		}
+	}
+}
+
+// subdocument renders a container separately, for constructs that prefix every
+// line of their content.
+func subdocument(n *html.Node) string {
+	sub := &markdownWriter{}
+	sub.walk(n)
+	return strings.TrimSuffix(sub.result(), "\n")
+}
+
+func inlineText(n *html.Node) string {
+	var sb strings.Builder
+	writeInline(&sb, n)
+	return collapseSpace(sb.String())
+}
+
+func writeInline(sb *strings.Builder, n *html.Node) {
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		writeInlineNode(sb, c)
+	}
+}
+
+func writeInlineNode(sb *strings.Builder, c *html.Node) {
+	switch c.Type {
+	case html.TextNode:
+		sb.WriteString(c.Data)
+	case html.ElementNode:
+		if htmlDropped[c.DataAtom] {
+			return
+		}
+		switch c.DataAtom {
+		case atom.A:
+			text := inlineText(c)
+			if href := usableURL(attr(c, "href")); href != "" {
+				sb.WriteString("[" + text + "](" + href + ")")
+				return
+			}
+			sb.WriteString(text)
+		case atom.Img:
+			alt := attr(c, "alt")
+			if src := usableURL(attr(c, "src")); src != "" {
+				sb.WriteString("![" + alt + "](" + src + ")")
+				return
+			}
+			if alt != "" {
+				sb.WriteString("![" + alt + "]")
+			}
+		case atom.Code:
+			if text := collapseSpace(rawText(c)); text != "" {
+				sb.WriteString("`" + text + "`")
+			}
+		case atom.Br:
+			sb.WriteString(" ")
+		default:
+			writeInline(sb, c)
+		}
+	}
+}
+
+// usableURL rejects data: URIs, where the base64 payloads that bloat a bundle
+// live.
+func usableURL(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" || strings.HasPrefix(strings.ToLower(trimmed), "data:") {
+		return ""
+	}
+	return trimmed
+}
+
+func renderList(list *html.Node, depth int) string {
+	indent := strings.Repeat("  ", depth)
+	ordered := list.DataAtom == atom.Ol
+	number := 1
+	if start, err := strconv.Atoi(attr(list, "start")); err == nil && ordered {
+		number = start
+	}
+
+	var lines []string
+	for li := list.FirstChild; li != nil; li = li.NextSibling {
+		if li.Type != html.ElementNode || li.DataAtom != atom.Li {
+			continue
+		}
+
+		marker := "- "
+		if ordered {
+			marker = strconv.Itoa(number) + ". "
+			number++
+		}
+
+		var nested []string
+		for c := li.FirstChild; c != nil; c = c.NextSibling {
+			if c.Type == html.ElementNode && (c.DataAtom == atom.Ul || c.DataAtom == atom.Ol) {
+				nested = append(nested, renderList(c, depth+1))
+			}
+		}
+
+		lines = append(lines, indent+marker+listItemText(li))
+		lines = append(lines, nested...)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// listItemText is an item's own text, excluding any nested list.
+func listItemText(li *html.Node) string {
+	var sb strings.Builder
+	for c := li.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type == html.ElementNode && (c.DataAtom == atom.Ul || c.DataAtom == atom.Ol) {
+			continue
+		}
+		writeInlineNode(&sb, c)
+	}
+	return collapseSpace(sb.String())
+}
+
+// codeFence keeps pre content verbatim, labelled from a highlight.js or prism
+// class when present.
+func codeFence(pre *html.Node) string {
+	lang := codeLanguage(pre)
+	if inner := firstElement(pre, atom.Code); inner != nil {
+		if lang == "" {
+			lang = codeLanguage(inner)
+		}
+	}
+
+	body := strings.Trim(rawText(pre), "\n")
+	return "```" + lang + "\n" + body + "\n```"
+}
+
+func codeLanguage(n *html.Node) string {
+	for _, class := range strings.Fields(attr(n, "class")) {
+		for _, prefix := range []string{"language-", "lang-"} {
+			if strings.HasPrefix(class, prefix) {
+				return strings.TrimPrefix(class, prefix)
+			}
+		}
+	}
+	return ""
+}
+
+// renderTable collapses each cell to one line; rowspan and colspan are ignored,
+// since neither survives the format.
+func renderTable(table *html.Node) string {
+	var rows [][]string
+	collectRows(table, &rows)
+	if len(rows) == 0 {
+		return ""
+	}
+
+	width := 0
+	for _, r := range rows {
+		if len(r) > width {
+			width = len(r)
+		}
+	}
+
+	pad := func(r []string) []string {
+		for len(r) < width {
+			r = append(r, "")
+		}
+		return r
+	}
+
+	var lines []string
+	lines = append(lines, "| "+strings.Join(pad(rows[0]), " | ")+" |")
+	lines = append(lines, "|"+strings.Repeat("---|", width))
+	for _, r := range rows[1:] {
+		lines = append(lines, "| "+strings.Join(pad(r), " | ")+" |")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func collectRows(n *html.Node, rows *[][]string) {
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type != html.ElementNode {
+			continue
+		}
+		if c.DataAtom == atom.Tr {
+			var cells []string
+			for cell := c.FirstChild; cell != nil; cell = cell.NextSibling {
+				if cell.Type == html.ElementNode && (cell.DataAtom == atom.Th || cell.DataAtom == atom.Td) {
+					cells = append(cells, strings.ReplaceAll(inlineText(cell), "|", "\\|"))
+				}
+			}
+			*rows = append(*rows, cells)
+			continue
+		}
+		collectRows(c, rows)
+	}
+}
+
+func htmlBody(doc *html.Node) *html.Node { return findElement(doc, atom.Body) }
+
+func findElement(n *html.Node, a atom.Atom) *html.Node {
+	if n.Type == html.ElementNode && n.DataAtom == a {
+		return n
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if found := findElement(c, a); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func firstElement(n *html.Node, a atom.Atom) *html.Node {
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type == html.ElementNode && c.DataAtom == a {
+			return c
+		}
+	}
+	return nil
+}
+
+// rawText concatenates descendant text without collapsing whitespace.
+func rawText(n *html.Node) string {
+	var sb strings.Builder
+	var walk func(*html.Node)
+	walk = func(node *html.Node) {
+		for c := node.FirstChild; c != nil; c = c.NextSibling {
+			switch c.Type {
+			case html.TextNode:
+				sb.WriteString(c.Data)
+			case html.ElementNode:
+				if !htmlDropped[c.DataAtom] {
+					walk(c)
+				}
+			}
+		}
+	}
+	walk(n)
+	return sb.String()
+}
+
+func attr(n *html.Node, name string) string {
+	for _, a := range n.Attr {
+		if a.Key == name {
+			return a.Val
+		}
+	}
+	return ""
+}
+
+func collapseSpace(s string) string {
+	return strings.TrimSpace(strings.Join(strings.Fields(s), " "))
+}
+
+func prefixLines(s, prefix string) string {
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		lines[i] = strings.TrimRight(prefix+l, " ")
+	}
+	return strings.Join(lines, "\n")
+}

--- a/pkg/lx/internal/html_test.go
+++ b/pkg/lx/internal/html_test.go
@@ -1,0 +1,178 @@
+package internal
+
+import (
+	"strings"
+	"testing"
+)
+
+func toMarkdown(t *testing.T, in string) string {
+	t.Helper()
+	got, err := HTMLToMarkdown(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("HTMLToMarkdown failed: %v", err)
+	}
+	return strings.TrimSpace(string(got))
+}
+
+func TestHTMLToMarkdownStructure(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"heading levels", "<h1>One</h1><h3>Three</h3>", "# One\n\n### Three"},
+		{"horizontal rule", "<p>a</p><hr><p>b</p>", "a\n\n---\n\nb"},
+		{"paragraphs", "<p>first</p><p>second</p>", "first\n\nsecond"},
+		{"link", `<p>see <a href="/docs">docs</a></p>`, "see [docs](/docs)"},
+		{"link without href", "<p>see <a>docs</a></p>", "see docs"},
+		{"inline code", "<p>use <code>make()</code></p>", "use `make()`"},
+		{"image", `<p><img src="/a.png" alt="Logo"></p>`, "![Logo](/a.png)"},
+		{"blockquote", "<blockquote><p>quoted</p></blockquote>", "> quoted"},
+		{"unordered list", "<ul><li>a</li><li>b</li></ul>", "- a\n- b"},
+		{"ordered list start", `<ol start="3"><li>c</li><li>d</li></ol>`, "3. c\n4. d"},
+		{"nested list", "<ul><li>a<ul><li>b</li></ul></li></ul>", "- a\n  - b"},
+		{"title is not content", "<html><head><title>T</title></head><body><p>x</p></body></html>", "x"},
+		{"whitespace collapses", "<p>a\n\n   b\tc</p>", "a b c"},
+		{"emphasis is dropped", "<p>a <strong>b</strong> <em>c</em></p>", "a b c"},
+		{"block level image", `<img src="/a.png" alt="A">`, "![A](/a.png)"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := toMarkdown(t, c.in); got != c.want {
+				t.Errorf("got:\n%s\nwant:\n%s", got, c.want)
+			}
+		})
+	}
+}
+
+func TestHTMLToMarkdownDropsChrome(t *testing.T) {
+	in := `<html><head><title>T</title><style>b{color:red}</style>
+	<script>var x=1</script></head><body>
+	<nav>Home</nav><header>Top</header><aside>Ads</aside>
+	<p>kept</p><footer>Bottom</footer><noscript>NS</noscript></body></html>`
+
+	got := toMarkdown(t, in)
+	for _, unwanted := range []string{"color:red", "var x", "Home", "Top", "Ads", "Bottom", "NS"} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("output kept %q:\n%s", unwanted, got)
+		}
+	}
+	if !strings.Contains(got, "kept") {
+		t.Errorf("output lost the body text:\n%s", got)
+	}
+}
+
+func TestHTMLToMarkdownPreservesCodeBlocks(t *testing.T) {
+	in := "<pre><code class=\"language-go\">func main() {\n\tif x {\n\t\treturn\n\t}\n}</code></pre>"
+	want := "```go\nfunc main() {\n\tif x {\n\t\treturn\n\t}\n}\n```"
+
+	if got := toMarkdown(t, in); got != want {
+		t.Errorf("got:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestHTMLToMarkdownCodeFenceWithoutLanguage(t *testing.T) {
+	if got := toMarkdown(t, "<pre>plain\n  text</pre>"); got != "```\nplain\n  text\n```" {
+		t.Errorf("got:\n%q", got)
+	}
+}
+
+func TestHTMLToMarkdownStripsDataURIs(t *testing.T) {
+	got := toMarkdown(t, `<p><img src="data:image/png;base64,AAAABBBB" alt="blob"></p>`)
+	if strings.Contains(got, "base64") || strings.Contains(got, "data:") {
+		t.Errorf("data URI survived: %s", got)
+	}
+	if got != "![blob]" {
+		t.Errorf("got %q, want %q", got, "![blob]")
+	}
+}
+
+func TestHTMLToMarkdownDataURILinkKeepsText(t *testing.T) {
+	got := toMarkdown(t, `<p><a href="data:text/plain,hi">click</a></p>`)
+	if got != "click" {
+		t.Errorf("got %q, want %q", got, "click")
+	}
+}
+
+func TestHTMLToMarkdownTable(t *testing.T) {
+	in := `<table><thead><tr><th>Field</th><th>Type</th></tr></thead>
+	<tbody><tr><td>id</td><td>int</td></tr></tbody></table>`
+	want := "| Field | Type |\n|---|---|\n| id | int |"
+
+	if got := toMarkdown(t, in); got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestHTMLToMarkdownTableEscapesPipes(t *testing.T) {
+	got := toMarkdown(t, "<table><tr><th>a</th></tr><tr><td>x | y</td></tr></table>")
+	if !strings.Contains(got, `x \| y`) {
+		t.Errorf("pipe not escaped:\n%s", got)
+	}
+}
+
+func TestHTMLToMarkdownTablePadsShortRows(t *testing.T) {
+	got := toMarkdown(t, "<table><tr><th>a</th><th>b</th></tr><tr><td>x</td></tr></table>")
+	want := "| a | b |\n|---|---|\n| x |  |"
+	if got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestHTMLToMarkdownHandlesMalformedInput(t *testing.T) {
+	got := toMarkdown(t, "<p>unclosed <b>bold <div>and a div")
+	if !strings.Contains(got, "unclosed") || !strings.Contains(got, "and a div") {
+		t.Errorf("lost content from malformed input:\n%s", got)
+	}
+}
+
+func TestHTMLToMarkdownEmptyDocument(t *testing.T) {
+	if got := toMarkdown(t, ""); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+func TestHTMLToMarkdownDefinitionListsAndBreaks(t *testing.T) {
+	cases := []struct{ name, in, want string }{
+		{"definition list", "<dl><dt>Term</dt><dd>Meaning</dd></dl>", "Term\n\nMeaning"},
+		{"br splits a line", "<p>a<br>b</p>", "a b"},
+		{"deep nesting", "<ul><li>a<ul><li>b<ul><li>c</li></ul></li></ul></li></ul>", "- a\n  - b\n    - c"},
+		{"pre without code", "<pre>  spaced  </pre>", "```\n  spaced  \n```"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := toMarkdown(t, c.in); got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// Page metadata is not content: nothing from head, including meta tags, appears.
+func TestHTMLToMarkdownIgnoresHeadMetadata(t *testing.T) {
+	in := `<html><head>
+	<title>Page Title</title>
+	<meta name="description" content="A description">
+	<meta property="og:title" content="Social Title">
+	<link rel="canonical" href="/canonical">
+	</head><body><h1>Real Heading</h1><p>Body.</p></body></html>`
+
+	got := toMarkdown(t, in)
+	for _, unwanted := range []string{"Page Title", "A description", "Social Title", "canonical"} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("output includes head metadata %q:\n%s", unwanted, got)
+		}
+	}
+	if got != "# Real Heading\n\nBody." {
+		t.Errorf("got:\n%s", got)
+	}
+}
+
+// A stray meta in the body must not leak either.
+func TestHTMLToMarkdownIgnoresMetaInBody(t *testing.T) {
+	got := toMarkdown(t, `<body><p>a</p><meta name="x" content="leaked"><p>b</p></body>`)
+	if strings.Contains(got, "leaked") {
+		t.Errorf("meta content leaked:\n%s", got)
+	}
+}

--- a/pkg/lx/render/processor.go
+++ b/pkg/lx/render/processor.go
@@ -179,35 +179,51 @@ func readerFor(rc io.ReadCloser, sizeHint int64) (io.ReaderAt, int64) {
 type converter struct {
 	name    string
 	applies func(sources.InputFile) bool
-	convert func(path string, r io.ReaderAt, size int64) ([]byte, error)
+	convert func(f sources.InputFile, r io.ReaderAt, size int64) ([]byte, error)
+	// language of the produced content; empty means detect as usual.
+	language func(f sources.InputFile) string
 }
 
 var converters = []converter{
 	{
 		name: "document",
 		applies: func(f sources.InputFile) bool {
-			return f.Config.ExtractDocuments && sources.IsDocumentPath(f.Path)
+			if !f.Config.ExtractDocuments {
+				return false
+			}
+			return sources.IsDocumentPath(f.Path) || sources.IsHTMLInput(f)
 		},
-		convert: sources.ExtractDocumentText,
+		convert: sources.ConvertInput,
+		language: func(f sources.InputFile) string {
+			// The other formats yield plain text, which detection leaves unlabelled.
+			if sources.IsHTMLInput(f) {
+				return "markdown"
+			}
+			return ""
+		},
 	},
 }
 
 // applyConverters reports the format it converted from, or "" if none applied.
 // A converter that fails leaves the content untouched.
-func applyConverters(file sources.InputFile, reader io.ReaderAt, size int64) (io.ReaderAt, int64, string) {
+func applyConverters(file sources.InputFile, reader io.ReaderAt, size int64) (io.ReaderAt, int64, string, string) {
 	for _, c := range converters {
 		if !c.applies(file) {
 			continue
 		}
-		text, err := c.convert(file.Path, reader, size)
+		text, err := c.convert(file, reader, size)
 		if err != nil {
 			slog.Debug("Converter failed, keeping raw content",
 				"converter", c.name, "path", file.Path, "error", err)
-			return reader, size, ""
+			return reader, size, "", ""
 		}
-		return bytes.NewReader(text), int64(len(text)), fileFormat(file.Path)
+		lang := ""
+		if c.language != nil {
+			lang = c.language(file)
+		}
+		return bytes.NewReader(text), int64(len(text)), fileFormat(file.Path), lang
 	}
-	return reader, size, ""
+	return reader, size, "", ""
 }
 
 // detectContent sniffs the header for binary content and a language hint.
@@ -284,13 +300,16 @@ func (p *Processor) prepareFileContext(file sources.InputFile, index int, scratc
 	}
 
 	reader, size := readerFor(rc, file.Size)
-	reader, size, convertedFrom := applyConverters(file, reader, size)
+	reader, size, convertedFrom, convertedLang := applyConverters(file, reader, size)
 
 	if scratch == nil {
 		scratch = make([]byte, 1024)
 	}
 
 	isBinary, lang := detectContent(file.Path, reader, scratch)
+	if convertedLang != "" {
+		lang = convertedLang
+	}
 	isImage := internal.IsImage(file.Path)
 	cfg := file.Config
 

--- a/pkg/lx/render/processor_test.go
+++ b/pkg/lx/render/processor_test.go
@@ -251,7 +251,7 @@ func TestApplyConvertersLeavesContentWhenNoneApply(t *testing.T) {
 	src := []byte("package main\n")
 	file := sources.NewBufferInputFile("main.go", src)
 
-	reader, size, from := applyConverters(file, bytes.NewReader(src), int64(len(src)))
+	reader, size, from, _ := applyConverters(file, bytes.NewReader(src), int64(len(src)))
 	if from != "" {
 		t.Errorf("convertedFrom = %q, want empty", from)
 	}
@@ -269,14 +269,14 @@ func TestApplyConvertersRunsMatchingConverter(t *testing.T) {
 	converters = append(converters, converter{
 		name:    "test",
 		applies: func(f sources.InputFile) bool { return strings.HasSuffix(f.Path, ".zzz") },
-		convert: func(path string, r io.ReaderAt, size int64) ([]byte, error) {
+		convert: func(f sources.InputFile, r io.ReaderAt, size int64) ([]byte, error) {
 			return []byte("converted"), nil
 		},
 	})
 	t.Cleanup(func() { converters = converters[:len(converters)-1] })
 
 	file := sources.NewBufferInputFile("doc.zzz", []byte("raw"))
-	reader, size, from := applyConverters(file, bytes.NewReader([]byte("raw")), 3)
+	reader, size, from, _ := applyConverters(file, bytes.NewReader([]byte("raw")), 3)
 
 	if from != "zzz" {
 		t.Errorf("convertedFrom = %q, want %q", from, "zzz")
@@ -293,14 +293,14 @@ func TestApplyConvertersKeepsContentOnFailure(t *testing.T) {
 	converters = append(converters, converter{
 		name:    "failing",
 		applies: func(f sources.InputFile) bool { return strings.HasSuffix(f.Path, ".zzz") },
-		convert: func(path string, r io.ReaderAt, size int64) ([]byte, error) {
+		convert: func(f sources.InputFile, r io.ReaderAt, size int64) ([]byte, error) {
 			return nil, io.ErrUnexpectedEOF
 		},
 	})
 	t.Cleanup(func() { converters = converters[:len(converters)-1] })
 
 	src := []byte("raw content")
-	reader, size, from := applyConverters(
+	reader, size, from, _ := applyConverters(
 		sources.NewBufferInputFile("doc.zzz", src), bytes.NewReader(src), int64(len(src)))
 
 	if from != "" {
@@ -399,5 +399,29 @@ func TestRenderPreparedNonFileItemHasZeroStats(t *testing.T) {
 	}
 	if stats != (RenderStats{}) {
 		t.Errorf("prompt item reported %+v, want zero stats", stats)
+	}
+}
+
+func TestApplyConvertersReportsProducedLanguage(t *testing.T) {
+	src := []byte("<h1>Hi</h1>")
+	file := sources.NewBufferInputFile("page.html", src)
+	file.Config = core.RunnerConfig{Head: -1, ExtractDocuments: true}
+
+	_, _, from, lang := applyConverters(file, bytes.NewReader(src), int64(len(src)))
+	if from != "html" {
+		t.Errorf("convertedFrom = %q, want html", from)
+	}
+	if lang != "markdown" {
+		t.Errorf("language = %q, want markdown", lang)
+	}
+}
+
+func TestApplyConvertersReportsNoLanguageWhenNoneApply(t *testing.T) {
+	src := []byte("package main\n")
+	file := sources.NewBufferInputFile("main.go", src)
+
+	_, _, from, lang := applyConverters(file, bytes.NewReader(src), int64(len(src)))
+	if from != "" || lang != "" {
+		t.Errorf("got from=%q lang=%q, want both empty", from, lang)
 	}
 }

--- a/pkg/lx/sources/document.go
+++ b/pkg/lx/sources/document.go
@@ -5,6 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"mime"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -12,10 +13,46 @@ import (
 
 	pdflib "github.com/ledongthuc/pdf"
 	"github.com/nguyenthenguyen/docx"
+	"github.com/rasros/lx/pkg/lx/internal"
 	"github.com/xuri/excelize/v2"
 )
 
-var documentSuffixes = []string{".pdf", ".docx", ".xlsx", ".pptx"}
+var documentSuffixes = []string{".pdf", ".docx", ".xlsx", ".pptx", ".html", ".htm", ".xhtml"}
+
+// isHTMLPath reports whether the path is an HTML document.
+func isHTMLPath(path string) bool {
+	lower := strings.ToLower(path)
+	return strings.HasSuffix(lower, ".html") || strings.HasSuffix(lower, ".htm") ||
+		strings.HasSuffix(lower, ".xhtml")
+}
+
+// IsHTMLInput reports whether an input should be treated as HTML. A suffix
+// settles it for files; URLs frequently have none, so the media type their
+// source reported decides those. A local file with neither — no HTML suffix and
+// no declared type — is left as-is, since nothing here inspects content.
+func IsHTMLInput(f InputFile) bool {
+	if isHTMLPath(f.Path) {
+		return true
+	}
+	return f.mediaType != nil && isHTMLMediaType(*f.mediaType)
+}
+
+func isHTMLMediaType(value string) bool {
+	mediaType, _, err := mime.ParseMediaType(value)
+	if err != nil {
+		return false
+	}
+	return mediaType == "text/html" || mediaType == "application/xhtml+xml"
+}
+
+// ConvertInput converts a document input to text, choosing the HTML path by
+// suffix or media type and falling back to the suffix-driven extractors.
+func ConvertInput(f InputFile, r io.ReaderAt, size int64) ([]byte, error) {
+	if IsHTMLInput(f) {
+		return internal.HTMLToMarkdown(io.NewSectionReader(r, 0, size))
+	}
+	return ExtractDocumentText(f.Path, r, size)
+}
 
 // IsDocumentPath reports whether the path has a document file extension.
 func IsDocumentPath(path string) bool {
@@ -40,6 +77,8 @@ func ExtractDocumentText(path string, r io.ReaderAt, size int64) ([]byte, error)
 		return extractXLSXText(r, size)
 	case ".pptx":
 		return extractPPTXText(r, size)
+	case ".html", ".htm", ".xhtml":
+		return internal.HTMLToMarkdown(io.NewSectionReader(r, 0, size))
 	}
 	return nil, fmt.Errorf("unsupported document type: %s", ext)
 }

--- a/pkg/lx/sources/document_test.go
+++ b/pkg/lx/sources/document_test.go
@@ -483,3 +483,38 @@ func TestExtractDocumentText_CaseInsensitiveExtension(t *testing.T) {
 		t.Errorf("expected 'case test', got %q", string(text))
 	}
 }
+
+func TestIsHTMLPath(t *testing.T) {
+	for _, p := range []string{"a.html", "a.HTM", "dir/b.xhtml"} {
+		if !isHTMLPath(p) {
+			t.Errorf("isHTMLPath(%q) = false, want true", p)
+		}
+	}
+	for _, p := range []string{"a.pdf", "a.htmlx", "a.txt", "html"} {
+		if isHTMLPath(p) {
+			t.Errorf("isHTMLPath(%q) = true, want false", p)
+		}
+	}
+}
+
+func TestIsDocumentPathIncludesHTML(t *testing.T) {
+	for _, p := range []string{"a.html", "a.htm", "a.xhtml", "a.pdf", "a.docx", "a.xlsx", "a.pptx"} {
+		if !IsDocumentPath(p) {
+			t.Errorf("IsDocumentPath(%q) = false, want true", p)
+		}
+	}
+}
+
+func TestExtractDocumentTextConvertsHTML(t *testing.T) {
+	for _, name := range []string{"page.html", "page.htm", "page.xhtml"} {
+		src := []byte("<h1>Title</h1><p>Body <code>x</code></p>")
+		got, err := ExtractDocumentText(name, bytes.NewReader(src), int64(len(src)))
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		want := "# Title\n\nBody `x`\n"
+		if string(got) != want {
+			t.Errorf("%s: got %q, want %q", name, got, want)
+		}
+	}
+}

--- a/pkg/lx/sources/fs.go
+++ b/pkg/lx/sources/fs.go
@@ -18,6 +18,11 @@ type InputFile struct {
 	Config core.RunnerConfig
 
 	Open func() (io.ReadCloser, error)
+
+	// mediaType is filled in by Open for sources that learn it while fetching,
+	// such as an HTTP response's Content-Type. It is shared by pointer so the
+	// value copies the pipeline makes all observe what Open recorded.
+	mediaType *string
 }
 
 type byteReaderReadCloser struct {

--- a/pkg/lx/sources/url.go
+++ b/pkg/lx/sources/url.go
@@ -37,10 +37,12 @@ func NewURLInputFile(raw string) (InputFile, error) {
 	}
 
 	uri := u.String()
+	mediaType := new(string)
 	return InputFile{
-		Path:    uri,
-		AbsPath: uri,
-		Size:    -1,
+		Path:      uri,
+		AbsPath:   uri,
+		Size:      -1,
+		mediaType: mediaType,
 		Open: func() (io.ReadCloser, error) {
 			req, err := http.NewRequest(http.MethodGet, uri, nil)
 			if err != nil {
@@ -54,6 +56,7 @@ func NewURLInputFile(raw string) (InputFile, error) {
 				resp.Body.Close()
 				return nil, fmt.Errorf("GET %q: unexpected status %s", uri, resp.Status)
 			}
+			*mediaType = resp.Header.Get("Content-Type")
 			return resp.Body, nil
 		},
 	}, nil

--- a/pkg/lx/sources/url_test.go
+++ b/pkg/lx/sources/url_test.go
@@ -196,3 +196,56 @@ func makeArchiveBytes(t *testing.T, files map[string]string) []byte {
 	}
 	return buf.Bytes()
 }
+
+func TestNewURLInputFileRecordsMediaType(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write([]byte("<h1>Hi</h1>"))
+	}))
+	defer srv.Close()
+
+	f, err := NewURLInputFile(srv.URL + "/docs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if IsHTMLInput(f) {
+		t.Error("IsHTMLInput = true before Open, when no media type is known yet")
+	}
+
+	rc, err := f.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rc.Close()
+
+	if got := *f.mediaType; got != "text/html; charset=utf-8" {
+		t.Errorf("recorded media type = %q", got)
+	}
+	if !IsHTMLInput(f) {
+		t.Error("IsHTMLInput = false for a text/html response")
+	}
+}
+
+func TestIsHTMLInputIgnoresOtherMediaTypes(t *testing.T) {
+	for _, ct := range []string{"text/plain", "application/octet-stream", "", "not a media type"} {
+		f := InputFile{Path: "https://example.com/docs", mediaType: &ct}
+		if IsHTMLInput(f) {
+			t.Errorf("IsHTMLInput = true for Content-Type %q", ct)
+		}
+	}
+	for _, ct := range []string{"text/html", "text/html; charset=utf-8", "application/xhtml+xml"} {
+		f := InputFile{Path: "https://example.com/docs", mediaType: &ct}
+		if !IsHTMLInput(f) {
+			t.Errorf("IsHTMLInput = false for Content-Type %q", ct)
+		}
+	}
+}
+
+func TestIsHTMLInputFallsBackToSuffix(t *testing.T) {
+	if !IsHTMLInput(InputFile{Path: "page.html"}) {
+		t.Error("IsHTMLInput = false for page.html")
+	}
+	if IsHTMLInput(InputFile{Path: "main.go"}) {
+		t.Error("IsHTMLInput = true for main.go")
+	}
+}


### PR DESCRIPTION
Adds HTML to -D, alongside the existing PDF, DOCX, XLSX and PPTX extraction. .html, .htm and .xhtml become structural Markdown instead of raw markup: headings become #, hr becomes ---, and lists, blockquotes, tables, links, images and fenced code survive, with the code language read from a highlight.js or prism class. Script, style, nav, header, footer, aside and noscript are dropped with their contents. data: URIs are stripped so base64 payloads cannot bloat a bundle, and pre content stays verbatim. Inline emphasis is not converted, to avoid escaping every literal * and _ in body text.

A suffix decides for local files; URLs usually have none, so their Content-Type decides instead. HTML is the only -D format emitting Markdown, and its fence is labelled accordingly. Without -D, HTML is still raw, so existing behaviour is unchanged. Uses golang.org/x/net/html, promoted from an indirect dependency. 34 unit tests, 11 golden cases.

Part of #81.