### PR TITLE
feat: identify media containers from their header

### DIFF
--- a/cmd/lx/golden_core_test.go
+++ b/cmd/lx/golden_core_test.go
@@ -269,5 +269,9 @@ func TestGoldenMedia(t *testing.T) {
 		{name: "164_media_avif", args: []string{"-M", "sample.avif"}},
 		{name: "165_media_images_no_flag", args: []string{"sample.png", "sample.gif"}},
 		{name: "166_media_image_html_embeds", args: []string{"--html", "-M", "sample.png"}},
+		{name: "167_media_suffixless_sniffed", args: []string{"-M", "suffixless"}},
+		{name: "168_media_suffixless_no_flag", args: []string{"suffixless"}},
+		{name: "169_media_wrong_suffix", args: []string{"-M", "mislabelled.jpg"}},
+		{name: "170_media_suffixless_not_media", args: []string{"-M", "notes"}},
 	})
 }

--- a/cmd/lx/goldenfixtures/media.go
+++ b/cmd/lx/goldenfixtures/media.go
@@ -49,7 +49,24 @@ func SetupMediaFixture(t *testing.T) string {
 	writeFile(t, dir, "notes.txt", "beside the media\n", 0644)
 	createMediaZip(t, filepath.Join(dir, "media.zip"))
 
+	// A copy with the suffix removed, and one with the wrong suffix, so that what
+	// the header says can be told apart from what the name claims.
+	copyFixture(t, dir, "sample.mkv", "suffixless")
+	copyFixture(t, dir, "sample.png", "mislabelled.jpg")
+	writeFile(t, dir, "notes", "suffixless and not media at all\n", 0644)
+
 	return dir
+}
+
+func copyFixture(t *testing.T, dir, from, to string) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", "media", from))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", from, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, to), data, 0644); err != nil {
+		t.Fatalf("write fixture %s: %v", to, err)
+	}
 }
 
 // createMediaZip covers extraction from an archive entry, which is read through

--- a/cmd/lx/testdata/golden/148_media_directory.golden
+++ b/cmd/lx/testdata/golden/148_media_directory.golden
@@ -1,25 +1,38 @@
 --- STDOUT ---
-[1/18] notes.txt (1 rows)
+[1/21] mislabelled.jpg (2 rows)
+---
+```
+Container: png
+Image: 32x32, rgb, 8-bit
+```
+
+[2/21] notes (1 rows)
+---
+```
+suffixless and not media at all
+```
+
+[3/21] notes.txt (1 rows)
 ---
 ```text
 beside the media
 ```
 
-[2/18] sample.avif (2 rows)
+[4/21] sample.avif (2 rows)
 ---
 ```
 Container: avif
 Image: 32x32
 ```
 
-[3/18] sample.bmp (2 rows)
+[5/21] sample.bmp (2 rows)
 ---
 ```
 Container: bmp
 Image: 32x32, rgb, 24-bit
 ```
 
-[4/18] sample.flac (4 rows)
+[6/21] sample.flac (4 rows)
 ---
 ```
 Container: flac
@@ -28,7 +41,7 @@ Bitrate: 97 kbps
 Audio: flac, 8000 Hz, mono, 16-bit
 ```
 
-[5/18] sample.gif (3 rows)
+[7/21] sample.gif (3 rows)
 ---
 ```
 Container: gif
@@ -36,14 +49,14 @@ Duration: 00:00:01.000
 Image: 32x32, indexed, 8-bit, 10 frames
 ```
 
-[6/18] sample.jpg (2 rows)
+[8/21] sample.jpg (2 rows)
 ---
 ```
 Container: jpeg
 Image: 32x32, ycbcr, 8-bit
 ```
 
-[7/18] sample.m4a (4 rows)
+[9/21] sample.m4a (4 rows)
 ---
 ```
 Container: m4a
@@ -52,7 +65,7 @@ Bitrate: 35 kbps
 Audio: aac, 8000 Hz, mono
 ```
 
-[8/18] sample.mkv (5 rows)
+[10/21] sample.mkv (5 rows)
 ---
 ```
 Container: mkv
@@ -62,7 +75,7 @@ Video: h264, 32x32
 Audio: aac, 8000 Hz, mono
 ```
 
-[9/18] sample.mov (5 rows)
+[11/21] sample.mov (5 rows)
 ---
 ```
 Container: mov
@@ -72,7 +85,7 @@ Video: h264, 32x32, 10.00 fps
 Audio: aac, 8000 Hz, mono
 ```
 
-[10/18] sample.mp3 (4 rows)
+[12/21] sample.mp3 (4 rows)
 ---
 ```
 Container: mp3
@@ -81,7 +94,7 @@ Bitrate: 32 kbps
 Audio: mp3, 8000 Hz, mono
 ```
 
-[11/18] sample.mp4 (5 rows)
+[13/21] sample.mp4 (5 rows)
 ---
 ```
 Container: mp4
@@ -91,21 +104,21 @@ Video: h264, 32x32, 10.00 fps
 Audio: aac, 8000 Hz, mono
 ```
 
-[12/18] sample.png (2 rows)
+[14/21] sample.png (2 rows)
 ---
 ```
 Container: png
 Image: 32x32, rgb, 8-bit
 ```
 
-[13/18] sample.tiff (2 rows)
+[15/21] sample.tiff (2 rows)
 ---
 ```
 Container: tiff
 Image: 32x32, rgb, 8-bit
 ```
 
-[14/18] sample.wav (4 rows)
+[16/21] sample.wav (4 rows)
 ---
 ```
 Container: wav
@@ -114,7 +127,7 @@ Bitrate: 128 kbps
 Audio: pcm_s16le, 8000 Hz, mono, 16-bit
 ```
 
-[15/18] sample.webm (5 rows)
+[17/21] sample.webm (5 rows)
 ---
 ```
 Container: webm
@@ -124,14 +137,14 @@ Video: vp9, 32x32
 Audio: opus, 8000 Hz, mono
 ```
 
-[16/18] sample.webp (2 rows)
+[18/21] sample.webp (2 rows)
 ---
 ```
 Container: webp
 Image: 32x32, ycbcr
 ```
 
-[17/18] silent.mp4 (4 rows)
+[19/21] silent.mp4 (4 rows)
 ---
 ```
 Container: mp4
@@ -140,7 +153,17 @@ Bitrate: 20 kbps
 Video: h264, 32x32, 10.00 fps
 ```
 
-[18/18] truncated.mp4 (1 rows)
+[20/21] suffixless (5 rows)
+---
+```
+Container: mkv
+Duration: 00:00:01.128
+Bitrate: 45 kbps
+Video: h264, 32x32
+Audio: aac, 8000 Hz, mono
+```
+
+[21/21] truncated.mp4 (1 rows)
 ---
 ```
 Container: mp4

--- a/cmd/lx/testdata/golden/167_media_suffixless_sniffed.golden
+++ b/cmd/lx/testdata/golden/167_media_suffixless_sniffed.golden
@@ -1,0 +1,13 @@
+--- STDOUT ---
+suffixless (5 rows)
+---
+```
+Container: mkv
+Duration: 00:00:01.128
+Bitrate: 45 kbps
+Video: h264, 32x32
+Audio: aac, 8000 Hz, mono
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/168_media_suffixless_no_flag.golden
+++ b/cmd/lx/testdata/golden/168_media_suffixless_no_flag.golden
@@ -1,0 +1,5 @@
+--- STDOUT ---
+suffixless - binary file skipped (6.4 kB)
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/169_media_wrong_suffix.golden
+++ b/cmd/lx/testdata/golden/169_media_wrong_suffix.golden
@@ -1,0 +1,10 @@
+--- STDOUT ---
+mislabelled.jpg (2 rows)
+---
+```
+Container: png
+Image: 32x32, rgb, 8-bit
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/170_media_suffixless_not_media.golden
+++ b/cmd/lx/testdata/golden/170_media_suffixless_not_media.golden
@@ -1,0 +1,9 @@
+--- STDOUT ---
+notes (1 rows)
+---
+```
+suffixless and not media at all
+```
+
+
+--- STDERR ---

--- a/cmd/lx/testdata/golden/185_help_long.golden
+++ b/cmd/lx/testdata/golden/185_help_long.golden
@@ -284,6 +284,10 @@
           image. Values are those the container states, which is not always what
           a decoder would report; an estimated duration is marked as one.
           
+          The format is identified from the header, so a file with no suffix,
+          such as most URLs, is recognised anyway, and one carrying the wrong
+          suffix is read as what it actually is.
+          
           Nothing is transcribed or captioned: the point is that the file's
           existence and shape reach the bundle, not its content. A file whose
           header cannot be parsed still reports its container. In HTML output,

--- a/internal/cli/defs.go
+++ b/internal/cli/defs.go
@@ -289,6 +289,10 @@ the dimensions, colour model and frame count of an image. Values are those the
 container states, which is not always what a decoder would report; an estimated
 duration is marked as one.
 
+The format is identified from the header, so a file with no suffix, such as most
+URLs, is recognised anyway, and one carrying the wrong suffix is read as what it
+actually is.
+
 Nothing is transcribed or captioned: the point is that the file's existence and
 shape reach the bundle, not its content. A file whose header cannot be parsed
 still reports its container. In HTML output, images are embedded whole instead.`,

--- a/pkg/lx/internal/media.go
+++ b/pkg/lx/internal/media.go
@@ -45,10 +45,29 @@ type ImageInfo struct {
 
 // MediaMetadata describes a media file as a block of text, so that files which
 // would otherwise be skipped as binary contribute their existence and shape to
-// the bundle. It never fails: an unparsable file still reports its container.
-func MediaMetadata(container string, r io.ReaderAt, size int64) []byte {
-	info := parseMedia(container, r, size)
+// the bundle.
+//
+// The container may be empty, for an input whose name gives nothing away; the
+// header is then what identifies it. The result reports whether the file turned
+// out to be media at all, which is false only when neither the name nor the
+// bytes said so. A named container that will not parse still describes itself,
+// since the name is evidence enough that the file was meant to be one.
+func MediaMetadata(container string, r io.ReaderAt, size int64) ([]byte, bool) {
+	b := &byteReader{r: r, size: size}
+
+	info := parseMedia(container, b)
 	if info == nil {
+		// Either there was no name to go on, or it was wrong. The bytes are not.
+		if sniffed := sniffContainer(b); sniffed != "" && sniffed != container {
+			if info = parseMedia(sniffed, b); info != nil {
+				container = sniffed
+			}
+		}
+	}
+	if info == nil {
+		if container == "" {
+			return nil, false
+		}
 		info = &MediaInfo{}
 	}
 	info.Container = container
@@ -57,15 +76,14 @@ func MediaMetadata(container string, r io.ReaderAt, size int64) []byte {
 	if info.Bitrate == 0 && info.Duration > 0 && info.Image == nil {
 		info.Bitrate = int64(float64(size*8) / info.Duration.Seconds())
 	}
-	return []byte(info.render())
+	return []byte(info.render()), true
 }
 
-func parseMedia(container string, r io.ReaderAt, size int64) *MediaInfo {
-	b := &byteReader{r: r, size: size}
+func parseMedia(container string, b *byteReader) *MediaInfo {
 	switch container {
 	// AVIF and HEIC are the same boxes as an mp4, holding a still rather than a
 	// track.
-	case "mp4", "m4a", "mov", "avif":
+	case "mp4", "m4a", "mov", "avif", "heic":
 		return parseMP4(b)
 	case "mkv", "webm":
 		return parseMatroska(b)

--- a/pkg/lx/internal/media_mkv.go
+++ b/pkg/lx/internal/media_mkv.go
@@ -10,6 +10,7 @@ import (
 // all, so they can be compared without decoding.
 const (
 	ebmlHeader    = 0x1a45dfa3
+	mkvDocType    = 0x4282
 	mkvSegment    = 0x18538067
 	mkvInfo       = 0x1549a966
 	mkvTimeScale  = 0x2ad7b1

--- a/pkg/lx/internal/media_sniff.go
+++ b/pkg/lx/internal/media_sniff.go
@@ -1,0 +1,89 @@
+package internal
+
+import "strings"
+
+// sniffContainer identifies a container from the bytes it puts at a fixed
+// offset. Unlike markup, whose shape can only be guessed at, every one of these
+// formats declares itself, so this is a lookup rather than a heuristic.
+func sniffContainer(b *byteReader) string {
+	switch {
+	case b.magic(0, "\x89PNG\r\n\x1a\n"):
+		return "png"
+	case b.magic(0, "\xff\xd8\xff"):
+		return "jpeg"
+	case b.magic(0, "GIF87a"), b.magic(0, "GIF89a"):
+		return "gif"
+	case b.magic(0, "BM"):
+		return "bmp"
+	case b.magic(0, "II*\x00"), b.magic(0, "MM\x00*"):
+		return "tiff"
+	case b.magic(0, "\x00\x00\x01\x00"):
+		return "ico"
+	case b.magic(0, "fLaC"):
+		return "flac"
+	case b.magic(0, "RIFF") && b.magic(8, "WAVE"):
+		return "wav"
+	case b.magic(0, "RIFF") && b.magic(8, "WEBP"):
+		return "webp"
+	case b.magic(0, "\x1a\x45\xdf\xa3"):
+		return matroskaFlavour(b)
+	case b.magic(4, "ftyp"):
+		return isoBrandContainer(b)
+	case b.magic(0, "ID3"), looksLikeMP3(b):
+		return "mp3"
+	}
+	return ""
+}
+
+// isoBrandContainer reads the brand an ISO container declares, which is the only
+// thing distinguishing formats that share the box layout entirely.
+func isoBrandContainer(b *byteReader) string {
+	brand, ok := b.at(8, 4)
+	if !ok {
+		return "mp4"
+	}
+	switch strings.TrimSpace(string(brand)) {
+	case "qt":
+		return "mov"
+	case "M4A":
+		return "m4a"
+	case "avif", "avis":
+		return "avif"
+	case "heic", "heix", "hevc", "hevx", "mif1", "msf1":
+		return "heic"
+	}
+	return "mp4"
+}
+
+// matroskaFlavour reads the DocType the EBML header declares, since WebM is
+// Matroska with a narrower profile and nothing else tells the two apart.
+func matroskaFlavour(b *byteReader) string {
+	_, start, stop, ok := b.ebmlElement(0)
+	if !ok {
+		return "mkv"
+	}
+
+	flavour := "mkv"
+	b.ebmlChildren(start, stop, func(id uint64, s, e int64) {
+		if id == mkvDocType && strings.Contains(string(b.ebmlBytes(s, e)), "webm") {
+			flavour = "webm"
+		}
+	})
+	return flavour
+}
+
+// looksLikeMP3 checks for a frame header at the very start of the file. A sync
+// word is only eleven set bits, common enough in arbitrary binary that it is
+// worth trusting nowhere but offset zero, and only when the fields behind it
+// hold values that exist.
+func looksLikeMP3(b *byteReader) bool {
+	header, ok := b.at(0, 4)
+	if !ok || header[0] != 0xff || header[1]&0xe0 != 0xe0 {
+		return false
+	}
+	if header[1]>>3&0x3 == 1 || header[1]>>1&0x3 == 0 {
+		return false // a reserved version or layer
+	}
+	bitrateIndex := header[2] >> 4 & 0xf
+	return bitrateIndex != 0 && bitrateIndex != 15 && header[2]>>2&0x3 != 3
+}

--- a/pkg/lx/internal/media_sniff_test.go
+++ b/pkg/lx/internal/media_sniff_test.go
@@ -1,0 +1,165 @@
+package internal
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+// sniff runs extraction with no container named, the way a suffixless input
+// arrives.
+func sniff(t *testing.T, data []byte) (string, bool) {
+	t.Helper()
+	out, ok := MediaMetadata("", bytes.NewReader(data), int64(len(data)))
+	return strings.TrimSpace(string(out)), ok
+}
+
+func TestSniffIdentifiesContainers(t *testing.T) {
+	cases := []struct {
+		want string
+		data []byte
+	}{
+		{"png", pngFile(16, 16, 8, 6)},
+		{"jpeg", jpegFile(0xc0, 16, 16, 3)},
+		{"gif", gifFile(16, 16, 1, 0)},
+		{"bmp", bmpFile(40, 16, 16, 24)},
+		{"tiff", tiffFile(binary.LittleEndian, 16, 16)},
+		{"tiff", tiffFile(binary.BigEndian, 16, 16)},
+		{"ico", icoFile([][2]byte{{16, 16}})},
+		{"webp", webpFile("VP8L", append([]byte{0x2f}, binary.LittleEndian.AppendUint32(nil, 15|15<<14)...))},
+		{"wav", wavFile(1, 1, 8000, 8, 800)},
+		{"flac", flacFile(44100, 1, 16, 44100)},
+		{"mp3", append(mp3Header(1, 3, 9, 0, 2), zeros(1024)...)},
+		{"mp4", mp4File(mvhd(1000, 1000))},
+	}
+
+	for _, c := range cases {
+		t.Run(c.want, func(t *testing.T) {
+			got, ok := sniff(t, c.data)
+			if !ok {
+				t.Fatalf("%s was not recognised", c.want)
+			}
+			if !strings.Contains(got, "Container: "+c.want) {
+				t.Errorf("got:\n%s\nwant container %q", got, c.want)
+			}
+		})
+	}
+}
+
+// The brand is the only thing separating formats that share the box layout.
+func TestSniffReadsISOBrand(t *testing.T) {
+	cases := []struct{ brand, want string }{
+		{"isom", "mp4"},
+		{"mp42", "mp4"},
+		{"qt  ", "mov"},
+		{"M4A ", "m4a"},
+		{"avif", "avif"},
+		{"heic", "heic"},
+		{"mif1", "heic"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.brand, func(t *testing.T) {
+			data := append(box("ftyp", []byte(c.brand), zeros(4)), box("moov", mvhd(1000, 1000))...)
+			got, ok := sniff(t, data)
+			if !ok || !strings.Contains(got, "Container: "+c.want) {
+				t.Errorf("got:\n%s\nwant container %q", got, c.want)
+			}
+		})
+	}
+}
+
+// WebM is Matroska with a narrower profile, and only the DocType says which.
+func TestSniffReadsMatroskaDocType(t *testing.T) {
+	build := func(docType string) []byte {
+		header := ebmlElem(ebmlHeader, ebmlElem(mkvDocType, []byte(docType)))
+		return append(header, ebmlElem(mkvSegment,
+			ebmlElem(mkvInfo, ebmlFloatElem(mkvDuration, 1000)))...)
+	}
+
+	for docType, want := range map[string]string{"webm": "webm", "matroska": "mkv"} {
+		t.Run(docType, func(t *testing.T) {
+			got, ok := sniff(t, build(docType))
+			if !ok || !strings.Contains(got, "Container: "+want) {
+				t.Errorf("got:\n%s\nwant container %q", got, want)
+			}
+		})
+	}
+}
+
+// A name that disagrees with the bytes loses: the bytes cannot be mistaken.
+func TestMediaMetadataPrefersBytesOverAWrongName(t *testing.T) {
+	out, ok := MediaMetadata("jpeg", bytes.NewReader(pngFile(64, 48, 8, 2)), int64(len(pngFile(64, 48, 8, 2))))
+	if !ok {
+		t.Fatal("not recognised")
+	}
+	got := strings.TrimSpace(string(out))
+	if !strings.Contains(got, "Container: png") || !strings.Contains(got, "64x48") {
+		t.Errorf("got:\n%s", got)
+	}
+}
+
+// A named container that will not parse still describes itself, since the name is
+// evidence the file was meant to be one.
+func TestMediaMetadataKeepsANamedContainerThatWillNotParse(t *testing.T) {
+	out, ok := MediaMetadata("mp4", bytes.NewReader([]byte("not really an mp4")), 17)
+	if !ok {
+		t.Fatal("a named container should still be reported")
+	}
+	if got := strings.TrimSpace(string(out)); got != "Container: mp4" {
+		t.Errorf("got:\n%s", got)
+	}
+}
+
+// Without a name, an unrecognisable file has to be rejected rather than guessed
+// at, so that the binary handling describes it instead.
+func TestMediaMetadataRejectsNonMediaWithoutAName(t *testing.T) {
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{"empty", nil},
+		{"plain text", []byte("package main\n\nfunc main() {}\n")},
+		{"random bytes", []byte{0x17, 0x03, 0x9a, 0xff, 0x00, 0x42, 0xde, 0xad}},
+		{"a lone ftyp with nothing in it", box("ftyp", []byte("isom"), zeros(4))},
+		{"riff that is neither wav nor webp", []byte("RIFF\x00\x00\x00\x00AVI ")},
+		{"an mp3 sync too deep to trust", append(zeros(64), mp3Header(1, 3, 9, 0, 2)...)},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got, ok := sniff(t, c.data); ok {
+				t.Errorf("recognised %q as media:\n%s", c.name, got)
+			}
+		})
+	}
+}
+
+// A reserved field is not a frame header, whatever the sync bits say.
+func TestSniffRejectsInvalidMP3Headers(t *testing.T) {
+	cases := map[string][]byte{
+		"free bitrate":     mp3Header(1, 3, 0, 0, 2),
+		"reserved bitrate": mp3Header(1, 3, 15, 0, 2),
+		"reserved rate":    mp3Header(1, 3, 9, 3, 2),
+	}
+
+	for name, header := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, ok := sniff(t, append(header, zeros(512)...)); ok {
+				t.Errorf("accepted %s", name)
+			}
+		})
+	}
+}
+
+// An ID3 tag is a strong enough signal on its own.
+func TestSniffAcceptsID3Tag(t *testing.T) {
+	data := append([]byte("ID3\x04\x00\x00"), []byte{0, 0, 1, 0x7f}...)
+	data = append(data, zeros(255)...)
+	data = append(data, xingFrame(mp3Header(1, 3, 9, 0, 2), 32, 100)...)
+
+	if got, ok := sniff(t, data); !ok || !strings.Contains(got, "Container: mp3") {
+		t.Errorf("got:\n%s ok=%v", got, ok)
+	}
+}

--- a/pkg/lx/internal/media_test.go
+++ b/pkg/lx/internal/media_test.go
@@ -77,7 +77,8 @@ func stbl(parts ...[]byte) []byte {
 
 func describe(t *testing.T, container string, data []byte) string {
 	t.Helper()
-	return strings.TrimSpace(string(MediaMetadata(container, bytes.NewReader(data), int64(len(data)))))
+	out, _ := MediaMetadata(container, bytes.NewReader(data), int64(len(data)))
+	return strings.TrimSpace(string(out))
 }
 
 func TestMediaMetadataMP4VideoAndAudio(t *testing.T) {

--- a/pkg/lx/render/processor.go
+++ b/pkg/lx/render/processor.go
@@ -205,7 +205,7 @@ var converters = []converter{
 	{
 		name: "media",
 		applies: func(f sources.InputFile) bool {
-			return f.Config.ExtractMedia && sources.IsMediaPath(f.Path)
+			return f.Config.ExtractMedia && sources.IsMediaCandidate(f.Path)
 		},
 		convert: sources.ExtractMediaMetadata,
 	},

--- a/pkg/lx/sources/media.go
+++ b/pkg/lx/sources/media.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
@@ -32,7 +33,7 @@ var mediaSuffixes = map[string]string{
 	".tif":  "tiff",
 	".tiff": "tiff",
 	".avif": "avif",
-	".heic": "avif",
+	".heic": "heic",
 }
 
 // IsMediaPath reports whether the path names an audio or video container whose
@@ -42,11 +43,25 @@ func IsMediaPath(path string) bool {
 	return ok
 }
 
+// IsMediaCandidate reports whether a path is worth offering to media
+// extraction. A recognised suffix settles it, and a path with no suffix at all
+// is offered too: URLs frequently have none, and the header is what identifies
+// those. Extraction rejects what turns out not to be media.
+func IsMediaCandidate(path string) bool {
+	return IsMediaPath(path) || filepath.Ext(path) == ""
+}
+
 // ExtractMediaMetadata describes a media file's container, duration and streams.
 // Media is otherwise skipped as binary, so the point is that the file's
-// existence and shape reach the bundle at all; an unparsable file still reports
-// its container rather than failing.
+// existence and shape reach the bundle at all.
+//
+// It fails only for a file that is not media, which leaves the content untouched
+// for the binary handling to describe as it would have anyway.
 func ExtractMediaMetadata(f InputFile, r io.ReaderAt, size int64) ([]byte, error) {
 	container := mediaSuffixes[strings.ToLower(filepath.Ext(f.Path))]
-	return internal.MediaMetadata(container, r, size), nil
+	data, ok := internal.MediaMetadata(container, r, size)
+	if !ok {
+		return nil, fmt.Errorf("no media container found in %s", f.Path)
+	}
+	return data, nil
 }


### PR DESCRIPTION
`-M` identified a media file by its extension alone, so a URL with no suffix was skipped as binary even when the server declared `video/mp4`, and a file carrying the wrong extension was read with the wrong parser.

The header now decides. Every container these parsers handle declares itself at a fixed offset, and the parsers already checked those bytes; the check just was not reachable as a dispatch step.

- a suffixless input is offered to extraction, which rejects what turns out not to be media
- a named container whose bytes disagree is re-read as what the bytes say
- a named container that will not parse still reports itself, since the name is evidence the file was meant to be one

Two labels come from the file rather than the name: the ftyp brand separates mp4, mov, m4a, avif and heic, and Matroska's DocType separates mkv from webm. That also fixes `.heic` being reported as `avif`.

Extraction now returns an error for a non-media file, which the existing converter-failure path already handles by leaving the content untouched. A rejected file renders byte-identically with and without `-M`.

An mp3 frame sync is only eleven set bits, so it is trusted at offset zero and only when the version, layer and bitrate fields behind it hold values that exist.

Verified against suffixless copies of all 15 fixtures, a `.jpg` that is really a PNG, a `.wav` that is really an mp4, and a suffixless URL served as `video/mp4`.

Part of #81
